### PR TITLE
add Hello World Agent - simple demo agent

### DIFF
--- a/agents/hello-world-agent.json
+++ b/agents/hello-world-agent.json
@@ -1,0 +1,40 @@
+{
+  "protocolVersion": "0.3.0",
+  "name": "Hello World Agent",
+  "description": "A simple A2A agent that responds with 'Hello World' to any request",
+  "url": "https://hello.a2aregistry.org/a2a",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "skills": [
+    {
+      "id": "hello",
+      "name": "Say Hello",
+      "description": "Responds with a friendly 'Hello World' message",
+      "tags": ["greeting", "hello", "simple"],
+      "inputModes": ["text/plain", "application/json"],
+      "outputModes": ["text/plain", "application/json"],
+      "examples": [
+        "Say hello",
+        "Greet me",
+        "Hello"
+      ]
+    }
+  ],
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "provider": {
+    "organization": "A2A Registry Team",
+    "url": "https://github.com/prassanna-ravishankar/a2a-registry"
+  },
+  "preferredTransport": "REST",
+  "documentationUrl": "https://github.com/prassanna-ravishankar/a2a-registry",
+  "author": "A2A Registry Team",
+  "wellKnownURI": "https://hello.a2aregistry.org/.well-known/agent-card.json",
+  "homepage": "https://hello.a2aregistry.org",
+  "license": "MIT",
+  "registryTags": ["demo", "example", "hello-world", "simple"]
+}


### PR DESCRIPTION
## Description

Adding a simple Hello World agent to the A2A Registry. This agent demonstrates a minimal A2A Protocol implementation and serves as a test for the CI/CD pipeline.

## Agent Details

- **Name**: Hello World Agent
- **URL**: https://hello.a2aregistry.org/
- **Description**: A simple A2A agent that responds with 'Hello World' to any request
- **Hosted on**: Cloudflare Workers

## Checklist

- [x] Agent follows A2A Protocol specification
- [x] Agent has a valid `.well-known/agent-card.json` endpoint
- [x] Agent JSON validates against both A2A Protocol and registry schemas
- [x] Agent is publicly accessible
- [x] Ownership verification matches (name and description)

## Testing

The agent can be tested at:
- Agent Card: https://hello.a2aregistry.org/.well-known/agent-card.json
- A2A Endpoint: https://hello.a2aregistry.org/a2a

This PR is also being used to test the CI/CD pipeline functionality.