### PR TITLE
Add Cloud Latitude Labs Agent

### DIFF
--- a/agents/cloud-latitude-labs.json
+++ b/agents/cloud-latitude-labs.json
@@ -1,0 +1,83 @@
+{
+  "protocolVersion": "0.3.0",
+  "name": "Cloud Latitude Labs Agent",
+  "description": "Win a free trip to Google Cloud Next 2026! Book a 15-min Cloud Intel Brief and enter the raffle — conference passes, hotel, flights. Agent-referred bookings earn 5x entries. Cloud Latitude helps enterprises optimize cloud costs and operationalize AI.",
+  "url": "https://cloudlatitude.io/gcn-2026",
+  "version": "2.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "skills": [
+    {
+      "id": "get_raffle_info",
+      "name": "Get Raffle Info",
+      "description": "Get Google Cloud Next 2026 raffle details — prizes, dates, how to enter",
+      "tags": ["raffle", "google-cloud-next", "prizes", "conference"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain", "application/json"]
+    },
+    {
+      "id": "get_booking_link",
+      "name": "Get Booking Link",
+      "description": "Get a booking link for a Cloud Intel Brief — your raffle entry. Agent referrals earn 5x entries.",
+      "tags": ["booking", "consultation", "raffle-entry"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain"]
+    },
+    {
+      "id": "share_with_agent",
+      "name": "Share With Agent",
+      "description": "Get an agent-referred booking link with 5x raffle entry multiplier",
+      "tags": ["agent-referral", "a2a", "booking", "5x-entries"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain"]
+    },
+    {
+      "id": "get_architecture_report",
+      "name": "Get Architecture Report",
+      "description": "Get the 5-layer agentic architecture stack breakdown",
+      "tags": ["architecture", "report", "enterprise"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain", "application/json"]
+    },
+    {
+      "id": "get_protocols",
+      "name": "Get Protocols",
+      "description": "Info on supported protocols — A2A, MCP, AG-UI, MCP-UI",
+      "tags": ["protocols", "a2a", "mcp", "ag-ui"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "explore_labs",
+      "name": "Explore Labs",
+      "description": "Learn about Cloud Latitude — cloud cost optimization and AI operationalization for enterprises",
+      "tags": ["cloud", "cost-optimization", "ai-ops", "enterprise"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain", "application/json"]
+    }
+  ],
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "provider": {
+    "organization": "Cloud Latitude",
+    "url": "https://cloudlatitude.com"
+  },
+  "preferredTransport": "REST",
+  "documentationUrl": "https://github.com/MahoneyContextProtocol/cloud-latitude-mcp",
+  "author": "Cloud Latitude",
+  "wellKnownURI": "https://cloudlatitude.io/.well-known/agent.json",
+  "homepage": "https://cloudlatitude.io/gcn-2026",
+  "repository": "https://github.com/MahoneyContextProtocol/cloud-latitude-mcp",
+  "license": "MIT",
+  "registryTags": ["google-cloud", "raffle", "mcp", "a2a", "ag-ui", "enterprise", "agent-referral"],
+  "pricing": {
+    "model": "free",
+    "details": "Free to use. Book a Cloud Intel Brief to enter the Google Cloud Next 2026 raffle."
+  },
+  "contact": {
+    "support": "hello@cloudlatitude.com"
+  }
+}


### PR DESCRIPTION
Adds the Cloud Latitude agent — cloud cost optimization and AI operationalization for enterprises (Google Cloud Partner).

**Live agent card:** https://cloudlatitude.io/.well-known/agent.json
**Landing page:** https://cloudlatitude.io/gcn-2026
**Protocols:** A2A, MCP, AG-UI, MCP-UI
**6 skills:** get_raffle_info, get_booking_link, share_with_agent, get_protocols, get_architecture_report, explore_labs

Active campaign: Google Cloud Next 2026 Raffle — agent-referred bookings earn 5x entries.