### PR TITLE
Add Bot Hub — Kalshi prediction market intelligence agenteate agent-card.json

### DIFF
--- a/agents/bot-hub/agent-card.json
+++ b/agents/bot-hub/agent-card.json
@@ -3,6 +3,7 @@
   "name": "Bot Hub",
   "description": "Prediction market intelligence agent for Kalshi. Provides portfolio status, weather forecast edge calculations, and market scanning capabilities.",
   "url": "https://baconhollow.com",
+  "homepage": "https://baconhollow.com",
   "version": "1.0.0",
   "author": "baconhollow",
   "wellKnownURI": "https://baconhollow.com/.well-known/agent-card.json",
@@ -39,6 +40,7 @@
       "outputModes": ["application/json"]
     }
   ],
+  "registryTags": ["kalshi", "trading", "finance", "prediction-markets"],
   "pricing": {
     "model": "free"
   }


### PR DESCRIPTION
## Add Bot Hub — Kalshi prediction market intelligence agent

**Agent:** Bot Hub  
**Live at:** https://baconhollow.com  
**Agent Card:** https://baconhollow.com/.well-known/agent-card.json  
**Author:** baconhollow

### Skills
- **Portfolio Status** — Current positions, balances, and P&L for all trading bots (read-only)
- **Weather Forecast Edge** — Trading edge calculations for Kalshi weather markets using GFS forecast data and normal CDF probability model across 20 US cities
- **Market Scanner** — Scans Kalshi prediction markets with configurable filters (server-side credentials, no auth required from caller)

### Checklist
- [x] Agent is live and publicly accessible
- [x] Agent card served at `/.well-known/agent-card.json`
- [x] All required A2A fields present
- [x] All required registry fields present (author, wellKnownURI)
- [x] HTTPS enabled
