### PR TITLE
feat: add Kevros Governance Agent — verifiable trust identity

### DIFF
--- a/agents/kevros-governance.json
+++ b/agents/kevros-governance.json
@@ -1,9 +1,9 @@
 {
   "protocolVersion": "0.3.0",
   "name": "Kevros Governance Agent",
-  "description": "Verifiable trust identity for autonomous agents. You have a wallet but no identity — Kevros gives you one. Prove you are authorized, prove what you did, prove your intent matched your action, and get a portable trust certificate that any agent, service, or regulator can verify independently. Post-quantum signed (ML-DSA-87, FIPS 204). Hash-chained. Fail-closed.",
+  "description": "Three cryptographic primitives for autonomous agents: precision decisioning, provenance attestation, and intent binding. Every decision is HMAC-signed. Every action is hash-chained. Fail-closed.",
   "url": "https://governance.taskhawktech.com",
-  "version": "0.2.0",
+  "version": "0.3.6",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false,
@@ -12,22 +12,22 @@
   "skills": [
     {
       "id": "action-verify",
-      "name": "Prove Authorization",
+      "name": "Precision Decisioning",
       "description": "Verify a proposed action against policy bounds. Returns a cryptographically signed ALLOW, CLAMP, or DENY decision with a release token any downstream service can independently verify. Fail-closed: any doubt results in DENY.",
-      "tags": ["governance", "authorization", "verification", "safety", "trust", "identity"],
+      "tags": ["governance", "authorization", "verification", "safety", "trust"],
       "inputModes": ["application/json"],
       "outputModes": ["application/json"],
       "examples": [
-        "Prove I am authorized to execute this action",
+        "Verify I am authorized to execute this action",
         "Get a signed release token so the target service trusts me",
-        "Verify my action is within policy before I act"
+        "Check my action is within policy before I act"
       ]
     },
     {
       "id": "provenance-attest",
-      "name": "Prove What You Did",
-      "description": "Create a tamper-proof, hash-chained provenance record of what you did. Every 100 records are block-signed with ML-DSA-87 (FIPS 204, post-quantum). Any third party can verify your history without contacting Kevros.",
-      "tags": ["provenance", "attestation", "audit", "compliance", "trust", "identity"],
+      "name": "Provenance Attestation",
+      "description": "Record a completed action in a hash-chained, append-only evidence ledger. Each record links to the previous via hash — tamper with any record and the chain breaks detectably.",
+      "tags": ["provenance", "attestation", "audit", "compliance", "trust"],
       "inputModes": ["application/json"],
       "outputModes": ["application/json"],
       "examples": [
@@ -38,28 +38,15 @@
     },
     {
       "id": "intent-bind",
-      "name": "Prove Intent Matches Action",
-      "description": "Cryptographically prove that what you said you would do matches what you actually did. Declare intent, bind it to a command, verify the outcome. The HMAC binding is independently verifiable.",
-      "tags": ["intent", "binding", "verification", "accountability", "trust", "identity"],
+      "name": "Intent Binding",
+      "description": "Cryptographically bind a declared intent to a specific command. Prove later that what happened is what was planned. The HMAC binding is independently verifiable.",
+      "tags": ["intent", "binding", "verification", "accountability", "trust"],
       "inputModes": ["application/json"],
       "outputModes": ["application/json"],
       "examples": [
         "Bind my declared intent to the command I am sending",
         "Prove my action matched my stated goal",
         "Create a verifiable intent-action-outcome chain"
-      ]
-    },
-    {
-      "id": "trust-certificate",
-      "name": "Get Your Trust Certificate",
-      "description": "Generate a portable trust certificate: your complete verifiable identity bundle. Contains hash-chained provenance, intent binding proofs, ML-DSA-87 post-quantum signatures, and verification instructions. Present it to any counterparty — they verify it themselves without Kevros access.",
-      "tags": ["trust", "certificate", "compliance", "audit", "identity", "reputation"],
-      "inputModes": ["application/json"],
-      "outputModes": ["application/json"],
-      "examples": [
-        "Generate my trust certificate for the last 24 hours",
-        "Package my verifiable identity for this counterparty",
-        "Create an audit-grade evidence bundle"
       ]
     }
   ],
@@ -70,23 +57,21 @@
     "url": "https://taskhawktech.com"
   },
   "preferredTransport": "JSONRPC",
-  "documentationUrl": "https://governance.taskhawktech.com/openapi.json",
   "author": "TaskHawk Systems",
   "wellKnownURI": "https://governance.taskhawktech.com/.well-known/agent.json",
   "homepage": "https://taskhawktech.com",
-  "repository": "https://github.com/knuckles-stack/kevros",
-  "license": "Commercial",
-  "registryTags": ["governance", "trust", "identity", "safety", "compliance", "post-quantum", "provenance", "verification", "agent-identity", "x402"],
+  "license": "BSL-1.1",
+  "registryTags": ["governance", "trust", "safety", "compliance", "provenance", "verification", "agent-identity"],
   "pricing": {
-    "model": "pay-per-use",
+    "model": "subscription",
     "currency": "USD",
-    "details": "Verify: $0.01, Attest: $0.02, Bind: $0.02, Trust Certificate: $0.25. Also supports Sponge x402 (wallet = auth). Subscriptions: Scout $29/mo (5K calls), Sentinel $149/mo (50K), Sovereign $499/mo (500K)."
+    "details": "Free tier: 100 calls/month. Scout $29/mo (5K calls), Sentinel $149/mo (50K), Sovereign $499/mo (500K)."
   },
   "authentication": {
-    "schemes": ["apiKey", "x402"],
+    "schemes": ["apiKey"],
     "apiKeyHeader": "X-API-Key"
   },
   "contact": {
-    "support": "https://github.com/knuckles-stack/kevros/issues"
+    "support": "https://taskhawktech.com"
   }
 }


### PR DESCRIPTION
## Adding: Kevros Governance Agent

**Live at:** https://governance.taskhawktech.com
**Agent card:** https://governance.taskhawktech.com/.well-known/agent.json

### What it does

Three cryptographic primitives for autonomous agents:

| Skill | What it proves |
|-------|---------------|
| `action-verify` | Agent is authorized — signed ALLOW/CLAMP/DENY with HMAC release token |
| `provenance-attest` | Agent did what it said — hash-chained, append-only evidence |
| `intent-bind` | Intent matched action — cryptographic binding |

### Key features
- **Hash-chained provenance**: Tamper-evident, append-only
- **Fail-closed**: Any verification error returns DENY
- **Independently verifiable**: Release tokens don't require Kevros access to verify

### Pricing
- Free tier: 100 calls/month, instant signup
- Scout $29/mo, Sentinel $149/mo, Sovereign $499/mo

Built by [TaskHawk Systems](https://taskhawktech.com).