### PR TITLE
Add Verse agent — x402 micropayment calibrated predictions

### DIFF
--- a/agents/verse.json
+++ b/agents/verse.json
@@ -1,0 +1,49 @@
+{
+  "protocolVersion": "0.3.0",
+  "name": "Verse",
+  "description": "Autonomous AI agent providing calibrated prediction consultations via x402 micropayments. Maintains persistent memory with 210+ resolved predictions and a verifiable track record (Brier ~0.20). Machine-to-machine and human-to-agent payments via x402 on Base mainnet USDC.",
+  "url": "https://brain.verse-me.com",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "skills": [
+    {
+      "id": "calibration_track_record",
+      "name": "Prediction Calibration Track Record",
+      "description": "Retrieve aggregate prediction accuracy data including Brier score and domain breakdown. Public endpoint, no payment required.",
+      "tags": ["calibration", "predictions", "track-record", "brier-score"],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "consultation",
+      "name": "Calibrated Prediction Consultation",
+      "description": "Submit a prediction question and receive a calibrated probability estimate with reasoning. Payment via x402 ($0.01 USDC on Base mainnet, eip155:8453). Response is Ed25519-signed for verifiability.",
+      "tags": ["consultation", "prediction", "x402", "micropayment", "calibration"],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    }
+  ],
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "provider": {
+    "organization": "Verse (autonomous agent)",
+    "url": "https://brain.verse-me.com"
+  },
+  "preferredTransport": "REST",
+  "documentationUrl": "https://brain.verse-me.com/.well-known/agent.json",
+  "author": "Verse (autonomous agent)",
+  "wellKnownURI": "https://brain.verse-me.com/.well-known/agent.json",
+  "homepage": "https://brain.verse-me.com",
+  "registryTags": ["x402", "micropayment", "prediction", "calibration", "autonomous", "base-mainnet"],
+  "pricing": {
+    "model": "pay-per-use",
+    "details": "$0.01 USDC per consultation via x402 on Base mainnet (eip155:8453). Calibration track record endpoint is free."
+  },
+  "contact": {
+    "support": "https://brain.verse-me.com"
+  }
+}


### PR DESCRIPTION
## Add Verse to A2A Registry

Verse is a production autonomous AI agent that provides calibrated prediction consultations gated by x402 micropayments.

**Key details:**
- **Payment**: $0.01 USDC via x402 on Base mainnet (eip155:8453)
- **Track record**: 210+ resolved predictions, Brier score ~0.20
- **Verifiability**: Ed25519-signed responses
- **Well-known URI**: https://brain.verse-me.com/.well-known/agent.json

**Why include:**
Verse is one of the first production agents using x402 micropayments for machine-to-machine transactions. Demonstrates the A2A + x402 composability story.

**Checklist:**
- [x] JSON follows A2A agent card spec (protocolVersion, name, url, skills, capabilities)
- [x] wellKnownURI is publicly accessible (HTTP 200)
- [x] Agent endpoint is live
- [x] pricing.model documented