### PR TITLE
fix: handle null provider and optional skill list fields from SDK model_dump

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,7 +91,7 @@ def _agent_create_from_card(
             protocolVersion=_extract_protocol_version(agent_card),
             name=agent_card["name"],
             description=agent_card.get("description", ""),
-            author=author_override or agent_card.get("provider", {}).get("organization", author_fallback),
+            author=author_override or (agent_card.get("provider") or {}).get("organization", author_fallback),
             wellKnownURI=well_known_uri,
             url=_extract_agent_url(agent_card),
             version=agent_card.get("version", "1.0.0"),

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,9 +14,9 @@ class Skill(BaseModel):
     name: str
     description: str
     tags: list[str] = Field(default_factory=list)
-    examples: list[str] = Field(default_factory=list)
-    inputModes: list[str] = Field(default_factory=list, alias="inputModes")  # noqa: N815
-    outputModes: list[str] = Field(default_factory=list, alias="outputModes")  # noqa: N815
+    examples: Optional[list[str]] = Field(default_factory=list)
+    inputModes: Optional[list[str]] = Field(default_factory=list, alias="inputModes")  # noqa: N815
+    outputModes: Optional[list[str]] = Field(default_factory=list, alias="outputModes")  # noqa: N815
 
     model_config = {"populate_by_name": True}
 


### PR DESCRIPTION
## Problem

When `fetch_agent_card` parses an agent card through the `a2a-sdk` `AgentCard` model and returns `model_dump(by_alias=True)`, optional fields (`provider`, `examples`, `inputModes`, `outputModes`) are serialized as explicit `None` rather than being absent from the dict. This causes two downstream crashes in `_agent_create_from_card`.

### Bug 1 — `provider: None` crash (`main.py`)

```python
# Before: default {} is ignored when the key exists with value None
author = agent_card.get("provider", {}).get("organization", fallback)

# After
author = (agent_card.get("provider") or {}).get("organization", fallback)
```

**Error:** `'NoneType' object has no attribute 'get'` → HTTP 400 `Invalid agent card format`

### Bug 2 — `Skill` list fields reject `None` (`models.py`)

The SDK emits `None` for unpopulated `examples`, `inputModes`, `outputModes` on skills. The `Skill` Pydantic model declares these as `list[str]` so Pydantic rejects `None` with a type error.

```python
# Before
examples: list[str] = Field(default_factory=list)
inputModes: list[str] = Field(default_factory=list, alias="inputModes")
outputModes: list[str] = Field(default_factory=list, alias="outputModes")

# After
examples: Optional[list[str]] = Field(default_factory=list)
inputModes: Optional[list[str]] = Field(default_factory=list, alias="inputModes")
outputModes: Optional[list[str]] = Field(default_factory=list, alias="outputModes")
```

**Error:** `Input should be a valid list [type=list_type, input_value=None]` → HTTP 400

## How it was found

Discovered while registering [a2a-browser](https://a2a-browser.digiant.nz) via `POST /api/agents/register`. The agent is now successfully registered after working around both bugs on the client side.

## Testing

Both bugs are reproducible by registering any agent whose card does not include `provider`, `examples`, `inputModes`, or `outputModes` fields — the SDK fills them with `None` during normalization, then both crashes occur sequentially.