### PR TITLE
feat(conformance): persist task-probe results on a daily cadence (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Base URL: `https://a2aregistry.org/api`
 | `capability` | Filter by A2A capability (streaming, pushNotifications) |
 | `author` | Filter by author name |
 | `conformance` | `standard` (A2A spec compliant) or `non-standard` |
+| `task_verified` | `true` = only agents whose last A2A `message/send` probe passed |
 | `limit` | Max results (default: 50, max: 100) |
 | `offset` | Pagination offset |
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ Base URL: `https://a2aregistry.org/api`
 | `limit` | Max results (default: 50, max: 100) |
 | `offset` | Pagination offset |
 
+## Quality signals
+
+Each agent carries three independent signals:
+
+| Signal | Probe | Cadence | What it means |
+|--------|-------|---------|---------------|
+| `is_healthy` | `GET <wellKnownURI>` | 30 min | Agent card endpoint reachable, returns valid JSON |
+| `conformance` | Schema-validate the card | 30 min | Card structure matches the A2A spec |
+| `task_conformance` | `message/send` via A2A SDK | daily | Endpoint actually responds to a real A2A request |
+
+`task_conformance` is the strongest signal for routing — a card can validate (`conformance = true`) while its endpoint 404s or rejects auth on POST. The daily probe runs the same classifier as registration-time smoke-tests; categories are exposed on `/api/agents` as `task_conformance.category` (one of `WORKING`, `404`, `405`, `401`/`402`/`403`/`400`, `NO_TRANSPORTS`, `DNS`, `VERSION`, `BAD_RESPONSE`, `BAD_JSON`, `METHOD`, `PARSE`, `AUTH_BACKEND`, `INTERNAL`, `TIMEOUT`, `OTHER`).
+
+Operators can identify our probes by User-Agent: `A2A-Registry-TaskProbe/1.0` for the daily worker run, `A2A-Registry-Smoke/1.0` for the registration-time check.
+
 ## Architecture
 
 ```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -323,6 +323,7 @@ async def list_agents(
     search: Optional[str] = None,
     conformance: Optional[str] = None,
     healthy: Optional[bool] = None,
+    task_verified: Optional[bool] = None,
     limit: int = 50,
     offset: int = 0,
 ):
@@ -336,6 +337,7 @@ async def list_agents(
     - author: Filter by author name (case-insensitive partial match)
     - conformance: Filter by conformance ("standard" or "non-standard")
     - healthy: Filter by health status (true = healthy, false = unhealthy)
+    - task_verified: true = only agents whose last A2A message/send probe passed
     - limit: Max results to return (default: 50, max: 100)
     - offset: Pagination offset (default: 0)
     """
@@ -347,6 +349,7 @@ async def list_agents(
         search=search,
         conformance=conformance,
         healthy=healthy,
+        task_verified=task_verified,
         limit=limit,
         offset=offset,
     )
@@ -367,6 +370,7 @@ async def list_agents(
         search=search,
         conformance=conformance,
         healthy=healthy,
+        task_verified=task_verified,
         limit=limit,
         offset=offset,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -235,14 +235,16 @@ async def register_agent_simple(registration: AgentRegister, request: Request):
 
     # Smoke test: send a real `message/send` to confirm the card actually leads
     # to a working endpoint. Hard-reject categories that indicate a broken card.
-    smoke_category, smoke_note = await smoke_test(well_known_uri)
+    smoke_category, smoke_note, smoke_ms = await smoke_test(well_known_uri)
     if should_reject(smoke_category):
         raise HTTPException(status_code=400, detail=rejection_message(smoke_category) or "Agent failed smoke test")
 
-    # Create agent, then attach smoke-test result as initial maintainer note.
+    # Create agent, then attach smoke-test result as initial maintainer note
+    # AND as the first task_conformance datapoint.
     try:
         created_agent = await agent_repo.create(agent_data)
         await agent_repo.update_maintainer_notes(created_agent.id, smoke_note)
+        await agent_repo.update_task_conformance(created_agent.id, smoke_category, smoke_ms)
         result = await agent_repo.get_by_id(created_agent.id)
         return result
     except Exception as e:
@@ -296,14 +298,16 @@ async def register_agent_full(agent: AgentCreate, request: Request):
         raise HTTPException(status_code=400, detail=f"Ownership verification failed: {message}")
 
     # Smoke test the live endpoint and hard-reject obviously broken cards.
-    smoke_category, smoke_note = await smoke_test(well_known_uri)
+    smoke_category, smoke_note, smoke_ms = await smoke_test(well_known_uri)
     if should_reject(smoke_category):
         raise HTTPException(status_code=400, detail=rejection_message(smoke_category) or "Agent failed smoke test")
 
-    # Create agent, then attach smoke-test result as initial maintainer note.
+    # Create agent, then attach smoke-test result as initial maintainer note
+    # AND as the first task_conformance datapoint.
     try:
         created_agent = await agent_repo.create(agent)
         await agent_repo.update_maintainer_notes(created_agent.id, smoke_note)
+        await agent_repo.update_task_conformance(created_agent.id, smoke_category, smoke_ms)
         result = await agent_repo.get_by_id(created_agent.id)
         logger.info("agent_registered", well_known_uri=well_known_uri, smoke=smoke_category)
         return result

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -98,6 +98,19 @@ class AgentInDB(AgentBase):
     maintainer_notes: Optional[str] = None
 
 
+class TaskConformance(BaseModel):
+    """
+    Result of the most recent A2A `message/send` probe.
+
+    Separate from `conformance` (which validates the agent card schema).
+    Lets clients distinguish "card looks right" from "endpoint actually works".
+    """
+    category: str
+    passed: bool
+    checked_at: datetime
+    response_ms: Optional[int] = None
+
+
 class AgentPublic(AgentInDB):
     """Public agent model with computed health metrics"""
     uptime_percentage: Optional[float] = None
@@ -105,6 +118,7 @@ class AgentPublic(AgentInDB):
     last_health_check: Optional[datetime] = None
     is_healthy: Optional[bool] = None
     status_notes: list[str] = Field(default_factory=list)
+    task_conformance: Optional[TaskConformance] = None
 
 
 class HealthCheck(BaseModel):

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -203,6 +203,7 @@ class AgentRepository:
         search: Optional[str] = None,
         conformance: Optional[str] = None,
         healthy: Optional[bool] = None,
+        task_verified: Optional[bool] = None,
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[AgentPublic], int]:
@@ -254,6 +255,11 @@ class AgentRepository:
             where_clauses.append("conformance = true")
         elif conformance == "non-standard":
             where_clauses.append("conformance IS NOT TRUE")
+
+        if task_verified is True:
+            where_clauses.append("task_conformance_passed = true")
+        elif task_verified is False:
+            where_clauses.append("task_conformance_passed IS NOT TRUE")
 
         # healthy filter uses a correlated subquery on the most recent health check
         if healthy is not None:

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -14,6 +14,7 @@ from .models import (
     HealthCheck,
     HealthStatus,
     RegistryStats,
+    TaskConformance,
     UptimeMetrics,
 )
 
@@ -388,6 +389,35 @@ class AgentRepository:
         )
         return result == "UPDATE 1"
 
+    async def update_task_conformance(
+        self,
+        agent_id: UUID,
+        category: str,
+        response_ms: Optional[int],
+    ) -> None:
+        """
+        Record the result of an A2A `message/send` task probe.
+
+        `passed` is derived: True iff category == 'WORKING'. Category values
+        are constrained at the DB level to the smoke_test.py taxonomy.
+        """
+        passed = category == "WORKING"
+        await self.db.execute(
+            """
+            UPDATE agents
+            SET task_conformance_category = $1,
+                task_conformance_passed = $2,
+                task_conformance_checked_at = NOW(),
+                task_conformance_response_ms = $3,
+                updated_at = NOW()
+            WHERE id = $4
+            """,
+            category,
+            passed,
+            response_ms,
+            agent_id,
+        )
+
     async def increment_flag_count(self, agent_id: UUID):
         """Increment flag count for an agent"""
         query = "UPDATE agents SET flag_count = flag_count + 1 WHERE id = $1"
@@ -435,6 +465,18 @@ class AgentRepository:
             conformance_errors=agent.conformance_errors,
             flag_count=agent.flag_count,
         )
+
+        task_conformance = None
+        tc_category = row.get("task_conformance_category")
+        tc_checked = row.get("task_conformance_checked_at")
+        if tc_category and tc_checked:
+            task_conformance = TaskConformance(
+                category=tc_category,
+                passed=bool(row.get("task_conformance_passed")),
+                checked_at=tc_checked,
+                response_ms=row.get("task_conformance_response_ms"),
+            )
+
         return AgentPublic(
             **agent.model_dump(),
             uptime_percentage=row.get("uptime_percentage"),
@@ -442,6 +484,7 @@ class AgentRepository:
             last_health_check=row.get("last_health_check"),
             is_healthy=row.get("is_healthy"),
             status_notes=status_notes,
+            task_conformance=task_conformance,
         )
 
 

--- a/backend/app/smoke_test.py
+++ b/backend/app/smoke_test.py
@@ -98,7 +98,7 @@ async def smoke_test(
     base_url = f"{parsed.scheme}://{parsed.netloc}"
     card_path = parsed.path or None
 
-    start = time.time()
+    start = time.monotonic()
 
     try:
         async with httpx.AsyncClient(

--- a/backend/app/smoke_test.py
+++ b/backend/app/smoke_test.py
@@ -5,6 +5,7 @@ Used at registration time to validate that the card actually leads to a working
 A2A endpoint. Returns a category + maintainer-note-ready message.
 """
 
+import time
 import uuid
 from typing import Optional
 from urllib.parse import urlparse
@@ -18,6 +19,12 @@ logger = structlog.get_logger()
 
 SMOKE_TEST_TIMEOUT_SECONDS = 15
 SMOKE_TEST_MESSAGE = "Hello, what can you do?"
+
+# Default UA for registration-time smoke tests. Worker uses TaskProbe UA so
+# operators can distinguish recurring probes from one-shot registration checks
+# in their access logs.
+SMOKE_TEST_USER_AGENT = "A2A-Registry-Smoke/1.0 (+https://a2aregistry.org)"
+TASK_PROBE_USER_AGENT = "A2A-Registry-TaskProbe/1.0 (+https://a2aregistry.org)"
 
 
 CATEGORY_NOTES = {
@@ -75,21 +82,29 @@ def classify_error(exc: BaseException) -> str:
     return "OTHER"
 
 
-async def smoke_test(well_known_uri: str) -> tuple[str, str]:
+async def smoke_test(
+    well_known_uri: str,
+    user_agent: str = SMOKE_TEST_USER_AGENT,
+) -> tuple[str, str, Optional[int]]:
     """
     Send a real A2A message/send to the agent and classify the result.
 
-    Returns (category, maintainer_note). Category is one of the keys in
-    CATEGORY_NOTES; maintainer_note is the human-readable message to store.
+    Returns (category, maintainer_note, response_ms). Category is one of the
+    keys in CATEGORY_NOTES; maintainer_note is the human-readable message;
+    response_ms is wall-clock time from connect to last streamed event (or to
+    failure), or None if no timing was captured.
     """
     parsed = urlparse(well_known_uri)
     base_url = f"{parsed.scheme}://{parsed.netloc}"
     card_path = parsed.path or None
 
+    start = time.time()
+
     try:
         async with httpx.AsyncClient(
             timeout=SMOKE_TEST_TIMEOUT_SECONDS,
             follow_redirects=True,
+            headers={"User-Agent": user_agent},
         ) as http_client:
             factory = ClientFactory(
                 ClientConfig(httpx_client=http_client, streaming=False),
@@ -104,10 +119,12 @@ async def smoke_test(well_known_uri: str) -> tuple[str, str]:
             saw_event = False
             async for _ in client.send_message(request):
                 saw_event = True
+            response_ms = int((time.time() - start) * 1000)
             if not saw_event:
-                return "BAD_RESPONSE", CATEGORY_NOTES["BAD_RESPONSE"]
-            return "WORKING", CATEGORY_NOTES["WORKING"]
+                return "BAD_RESPONSE", CATEGORY_NOTES["BAD_RESPONSE"], response_ms
+            return "WORKING", CATEGORY_NOTES["WORKING"], response_ms
     except Exception as exc:
+        response_ms = int((time.time() - start) * 1000)
         category = classify_error(exc)
         logger.info(
             "smoke_test_failed",
@@ -116,7 +133,7 @@ async def smoke_test(well_known_uri: str) -> tuple[str, str]:
             exc_type=type(exc).__name__,
             exc_msg=str(exc)[:200],
         )
-        return category, CATEGORY_NOTES.get(category, CATEGORY_NOTES["OTHER"])
+        return category, CATEGORY_NOTES.get(category, CATEGORY_NOTES["OTHER"]), response_ms
 
 
 # Categories that should hard-reject registration (operator must fix the card).

--- a/backend/migrations/versions/007_add_task_conformance.sql
+++ b/backend/migrations/versions/007_add_task_conformance.sql
@@ -1,0 +1,24 @@
+-- Task conformance: results from periodic A2A message/send probes (smoke_test.py).
+-- Separate from `conformance` (card schema validation). NULL = not yet probed.
+ALTER TABLE agents ADD COLUMN task_conformance_category TEXT;
+ALTER TABLE agents ADD COLUMN task_conformance_passed BOOLEAN;
+ALTER TABLE agents ADD COLUMN task_conformance_checked_at TIMESTAMPTZ;
+ALTER TABLE agents ADD COLUMN task_conformance_response_ms INTEGER;
+
+-- Restrict category to the smoke_test.py taxonomy so values don't drift.
+ALTER TABLE agents ADD CONSTRAINT agents_task_conformance_category_check
+    CHECK (task_conformance_category IS NULL OR task_conformance_category IN (
+        'WORKING',
+        'NO_TRANSPORTS',
+        '404', '405', '401', '402', '403', '400',
+        'DNS',
+        'VERSION',
+        'BAD_RESPONSE',
+        'BAD_JSON',
+        'METHOD',
+        'PARSE',
+        'AUTH_BACKEND',
+        'INTERNAL',
+        'TIMEOUT',
+        'OTHER'
+    ));

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -66,13 +66,14 @@ def test_register_agent_success(client):
     with patch("app.main.AgentRepository") as mock_repo, \
          patch("app.main.validate_well_known_uri", return_value=[]), \
          patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)), \
-         patch("app.main.smoke_test", new=AsyncMock(return_value=("WORKING", "Verified working at registration."))):
+         patch("app.main.smoke_test", new=AsyncMock(return_value=("WORKING", "Verified working at registration.", 123))):
         instance = mock_repo.return_value
         instance.get_by_well_known_uri = AsyncMock(return_value=None)
         instance.get_by_host = AsyncMock(return_value=None)
         instance.get_by_name_and_author = AsyncMock(return_value=None)
         instance.create = AsyncMock(return_value=_make_agent_in_db())
         instance.update_maintainer_notes = AsyncMock(return_value=True)
+        instance.update_task_conformance = AsyncMock(return_value=None)
         instance.get_by_id = AsyncMock(return_value=mock_public)
 
         response = client.post(
@@ -90,7 +91,7 @@ def test_register_agent_smoke_test_rejects_no_transports(client):
     with patch("app.main.AgentRepository") as mock_repo, \
          patch("app.main.validate_well_known_uri", return_value=[]), \
          patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)), \
-         patch("app.main.smoke_test", new=AsyncMock(return_value=("NO_TRANSPORTS", "Agent card does not declare any transports compatible with the A2A SDK"))):
+         patch("app.main.smoke_test", new=AsyncMock(return_value=("NO_TRANSPORTS", "Agent card does not declare any transports compatible with the A2A SDK", None))):
         instance = mock_repo.return_value
         instance.get_by_well_known_uri = AsyncMock(return_value=None)
         instance.get_by_host = AsyncMock(return_value=None)
@@ -113,13 +114,14 @@ def test_register_agent_smoke_test_failure_attaches_note(client):
     with patch("app.main.AgentRepository") as mock_repo, \
          patch("app.main.validate_well_known_uri", return_value=[]), \
          patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)), \
-         patch("app.main.smoke_test", new=AsyncMock(return_value=("404", note))):
+         patch("app.main.smoke_test", new=AsyncMock(return_value=("404", note, 87))):
         instance = mock_repo.return_value
         instance.get_by_well_known_uri = AsyncMock(return_value=None)
         instance.get_by_host = AsyncMock(return_value=None)
         instance.get_by_name_and_author = AsyncMock(return_value=None)
         instance.create = AsyncMock(return_value=_make_agent_in_db())
         instance.update_maintainer_notes = AsyncMock(return_value=True)
+        instance.update_task_conformance = AsyncMock(return_value=None)
         instance.get_by_id = AsyncMock(return_value=mock_public)
 
         response = client.post(

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -21,11 +21,10 @@ HEARTBEAT_FILE = Path("/tmp/worker-heartbeat")
 _cycle_count = 0
 # Check dead agents every N cycles (e.g. 48 cycles * 30 min = ~daily)
 DEAD_AGENT_CHECK_INTERVAL = 48
-# Probe POST message/send on the same cadence — once per day, not every 30min.
-# Hitting every agent's task endpoint twice an hour would be rude. Reuses
-# DEAD_AGENT_CHECK_INTERVAL boundary so probes and dead-agent revalidation
-# land in the same daily "deep cycle".
-TASK_PROBE_INTERVAL = DEAD_AGENT_CHECK_INTERVAL
+# Task probe staleness: re-probe an agent if its last `message/send` check is
+# older than this. DB-backed (task_conformance_checked_at), so the schedule
+# survives worker restarts — every cycle re-evaluates which agents are stale.
+TASK_PROBE_STALENESS = "24 hours"
 
 configure_logging(json_logs=True)
 logger = get_logger(__name__)
@@ -155,6 +154,28 @@ async def check_agent_health(
         bound_logger.error("health_check_error", error=error_message)
 
 
+async def _agents_needing_task_probe(agents) -> set:
+    """
+    Return the set of agent_ids whose last task probe is stale (or never run).
+
+    A single query keeps this cheap regardless of agent count. We pass in the
+    candidate set so we only ever consider live (non-dead) agents.
+    """
+    if not agents:
+        return set()
+    agent_ids = [a.id for a in agents]
+    rows = await db.fetch(
+        f"""
+        SELECT id FROM agents
+        WHERE id = ANY($1::uuid[])
+          AND (task_conformance_checked_at IS NULL
+               OR task_conformance_checked_at < NOW() - INTERVAL '{TASK_PROBE_STALENESS}')
+        """,
+        agent_ids,
+    )
+    return {row["id"] for row in rows}
+
+
 async def probe_one_task(agent, agent_repo: AgentRepository) -> str:
     """Send an A2A message/send to one agent and persist the result category."""
     bound_logger = logger.bind(agent_id=agent.id)
@@ -262,15 +283,17 @@ async def health_check_cycle():
                     if isinstance(result, Exception):
                         logger.error("health_check_task_error", error=str(result))
 
-        # Task probe (daily): real A2A message/send via the SDK. Persists a
-        # structured category so the UI can show "task-verified" alongside
-        # the cheaper GET-only health signal.
-        if _cycle_count % TASK_PROBE_INTERVAL == 0:
-            try:
-                probed = await run_task_probes(agent_repo, check_agents)
-                logger.info("task_probe_cycle_done", probed=probed)
-            except Exception as probe_err:
-                logger.warning("task_probe_cycle_failed", error=str(probe_err))
+        # Task probes: real A2A message/send via the SDK, persisted as a
+        # structured category. DB-driven (re-probe agents whose last probe is
+        # >24h old) instead of a cycle-counter — survives worker restarts.
+        try:
+            stale_ids = await _agents_needing_task_probe(check_agents)
+            stale_agents = [a for a in check_agents if a.id in stale_ids]
+            if stale_agents:
+                probed = await run_task_probes(agent_repo, stale_agents)
+                logger.info("task_probe_cycle_done", probed=probed, eligible=len(stale_agents))
+        except Exception as probe_err:
+            logger.warning("task_probe_cycle_failed", error=str(probe_err))
 
         # Prune health_checks older than 90 days
         try:

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -12,6 +12,7 @@ from app.config import settings
 from app.database import db
 from app.logging_config import configure_logging, get_logger
 from app.repositories import AgentRepository, HealthCheckRepository
+from app.smoke_test import TASK_PROBE_USER_AGENT, smoke_test
 from app.validators import validate_agent_card
 
 HEARTBEAT_FILE = Path("/tmp/worker-heartbeat")
@@ -20,6 +21,11 @@ HEARTBEAT_FILE = Path("/tmp/worker-heartbeat")
 _cycle_count = 0
 # Check dead agents every N cycles (e.g. 48 cycles * 30 min = ~daily)
 DEAD_AGENT_CHECK_INTERVAL = 48
+# Probe POST message/send on the same cadence — once per day, not every 30min.
+# Hitting every agent's task endpoint twice an hour would be rude. Reuses
+# DEAD_AGENT_CHECK_INTERVAL boundary so probes and dead-agent revalidation
+# land in the same daily "deep cycle".
+TASK_PROBE_INTERVAL = DEAD_AGENT_CHECK_INTERVAL
 
 configure_logging(json_logs=True)
 logger = get_logger(__name__)
@@ -149,6 +155,48 @@ async def check_agent_health(
         bound_logger.error("health_check_error", error=error_message)
 
 
+async def probe_one_task(agent, agent_repo: AgentRepository) -> str:
+    """Send an A2A message/send to one agent and persist the result category."""
+    bound_logger = logger.bind(agent_id=agent.id)
+    try:
+        category, _note, response_ms = await smoke_test(
+            str(agent.wellKnownURI),
+            user_agent=TASK_PROBE_USER_AGENT,
+        )
+        await agent_repo.update_task_conformance(agent.id, category, response_ms)
+        bound_logger.debug("task_probe_done", category=category, response_ms=response_ms)
+        return category
+    except Exception as exc:
+        # Don't let one probe failure crash the batch.
+        bound_logger.warning("task_probe_error", error=str(exc)[:120])
+        return "OTHER"
+
+
+async def run_task_probes(agent_repo: AgentRepository, agents) -> int:
+    """
+    Probe every supplied agent for A2A `message/send` conformance.
+
+    Smaller batches than the GET health cycle (probes are slower and hit a
+    real endpoint, not just an agent-card JSON file).
+    """
+    BATCH = 10
+    PAUSE_S = 2
+
+    total = 0
+    batch: list = []
+    for agent in agents:
+        batch.append(probe_one_task(agent, agent_repo))
+        if len(batch) >= BATCH:
+            await asyncio.gather(*batch, return_exceptions=True)
+            total += len(batch)
+            batch = []
+            await asyncio.sleep(PAUSE_S)
+    if batch:
+        await asyncio.gather(*batch, return_exceptions=True)
+        total += len(batch)
+    return total
+
+
 async def health_check_cycle():
     """Run a single health check cycle for all agents"""
     global _cycle_count
@@ -213,6 +261,16 @@ async def health_check_cycle():
                 for result in results:
                     if isinstance(result, Exception):
                         logger.error("health_check_task_error", error=str(result))
+
+        # Task probe (daily): real A2A message/send via the SDK. Persists a
+        # structured category so the UI can show "task-verified" alongside
+        # the cheaper GET-only health signal.
+        if _cycle_count % TASK_PROBE_INTERVAL == 0:
+            try:
+                probed = await run_task_probes(agent_repo, check_agents)
+                logger.info("task_probe_cycle_done", probed=probed)
+            except Exception as probe_err:
+                logger.warning("task_probe_cycle_failed", error=str(probe_err))
 
         # Prune health_checks older than 90 days
         try:

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -22,6 +22,7 @@ import aiohttp
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
 
+from app.smoke_test import TASK_PROBE_USER_AGENT, smoke_test
 from app.validators import validate_agent_card
 
 REGISTRY_API = "https://a2aregistry.org/api"
@@ -40,12 +41,21 @@ class Result:
     errors: list[str] = field(default_factory=list)
     fetch_error: Optional[str] = None
     response_ms: Optional[int] = None
+    # Populated when --probe-tasks is set. Mirrors the smoke_test taxonomy.
+    task_category: Optional[str] = None
+    task_response_ms: Optional[int] = None
 
     @property
     def conformant(self) -> Optional[bool]:
         if not self.reachable:
             return None
         return len(self.errors) == 0
+
+    @property
+    def task_passed(self) -> Optional[bool]:
+        if self.task_category is None:
+            return None
+        return self.task_category == "WORKING"
 
 
 async def fetch_all_agents(session: aiohttp.ClientSession) -> list[dict]:
@@ -63,7 +73,7 @@ async def fetch_all_agents(session: aiohttp.ClientSession) -> list[dict]:
     return agents
 
 
-async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool) -> Result:
+async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool, probe_tasks: bool = False) -> Result:
     result = Result(
         name=agent["name"],
         well_known_uri=agent.get("wellKnownURI", ""),
@@ -100,6 +110,21 @@ async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool) -
             result.reachable = True
             result.errors = validate_agent_card(card, strict=strict)
 
+        # If requested, run the same A2A message/send probe the worker uses
+        # so offline scans match production behavior.
+        if probe_tasks and result.reachable:
+            try:
+                category, _note, task_ms = await smoke_test(
+                    result.well_known_uri,
+                    user_agent=TASK_PROBE_USER_AGENT,
+                )
+                result.task_category = category
+                result.task_response_ms = task_ms
+            except Exception as e:
+                result.task_category = "OTHER"
+                result.task_response_ms = None
+                result.fetch_error = (result.fetch_error or "") + f" task-probe error: {str(e)[:80]}"
+
     except asyncio.TimeoutError:
         result.fetch_error = f"Timeout (>{TIMEOUT}s)"
         result.response_ms = TIMEOUT * 1000
@@ -111,18 +136,21 @@ async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool) -
     return result
 
 
-async def main(strict: bool, as_json: bool):
+async def main(strict: bool, as_json: bool, probe_tasks: bool):
     connector = aiohttp.TCPConnector(limit=CONCURRENCY)
     async with aiohttp.ClientSession(connector=connector) as session:
         print("Fetching agent list...", file=sys.stderr)
         agents = await fetch_all_agents(session)
-        print(f"Checking {len(agents)} agents (strict={strict})...\n", file=sys.stderr)
+        print(
+            f"Checking {len(agents)} agents (strict={strict}, probe_tasks={probe_tasks})...\n",
+            file=sys.stderr,
+        )
 
         sem = asyncio.Semaphore(CONCURRENCY)
 
         async def bounded(agent):
             async with sem:
-                return await check_one(agent, session, strict)
+                return await check_one(agent, session, strict, probe_tasks=probe_tasks)
 
         results = await asyncio.gather(*[bounded(a) for a in agents])
 
@@ -145,6 +173,9 @@ async def main(strict: bool, as_json: bool):
                 "response_ms": r.response_ms,
                 "errors": r.errors,
                 "fetch_error": r.fetch_error,
+                "task_category": r.task_category,
+                "task_passed": r.task_passed,
+                "task_response_ms": r.task_response_ms,
             })
         print(json.dumps(out, indent=2))
         return
@@ -194,5 +225,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--strict", action="store_true", help="Full A2A spec validation (requires all fields)")
     parser.add_argument("--json", dest="as_json", action="store_true", help="JSON output")
+    parser.add_argument("--probe-tasks", dest="probe_tasks", action="store_true",
+                        help="Also send A2A message/send to each agent (matches worker behavior)")
     args = parser.parse_args()
-    asyncio.run(main(strict=args.strict, as_json=args.as_json))
+    asyncio.run(main(strict=args.strict, as_json=args.as_json, probe_tasks=args.probe_tasks))

--- a/website/src/components/AgentCard.jsx
+++ b/website/src/components/AgentCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowUpRight, ShieldCheck, ShieldAlert, Radio, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { ArrowUpRight, ShieldCheck, ShieldAlert, Radio, CheckCircle2, AlertTriangle, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import HealthBadge from './HealthBadge';
@@ -8,7 +8,12 @@ const AgentCard = ({ agent, isSelected, onClick }) => {
     const provider = agent.author || agent.provider?.organization || 'Unknown';
     const topTags = agent.skills.flatMap((skill) => skill.tags || []).slice(0, 3);
     const notes = agent.maintainer_notes || '';
-    const isVerified = notes.startsWith('Verified working');
+    // Prefer the structured task_conformance signal — it's kept current by the
+    // daily worker probe. Fall back to maintainer_notes for agents that haven't
+    // been re-probed since the field was introduced.
+    const tc = agent.task_conformance;
+    const taskVerified = tc ? tc.passed === true : notes.startsWith('Verified working');
+    const isVerified = taskVerified;
     const hasIssue = notes && !isVerified;
 
     return (
@@ -55,6 +60,16 @@ const AgentCard = ({ agent, isSelected, onClick }) => {
                             <Badge variant="outline" className="rounded-none border-blue-500/30 bg-blue-500/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-blue-300">
                                 <CheckCircle2 className="mr-1 h-3 w-3" />
                                 Verified
+                            </Badge>
+                        )}
+                        {tc && tc.passed === true && (
+                            <Badge
+                                variant="outline"
+                                title={`A2A message/send probe succeeded at ${new Date(tc.checked_at).toLocaleString()}`}
+                                className="rounded-none border-emerald-500/30 bg-emerald-500/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300"
+                            >
+                                <Zap className="mr-1 h-3 w-3" />
+                                Task-verified
                             </Badge>
                         )}
                     </div>

--- a/website/src/components/HomeApp.jsx
+++ b/website/src/components/HomeApp.jsx
@@ -38,6 +38,7 @@ const HomeApp = () => {
   const [selectedSkills, setSelectedSkills] = useState([]);
   const [conformanceFilter, setConformanceFilter] = useState('standard');
   const [healthyOnly, setHealthyOnly] = useState(true);
+  const [taskVerifiedOnly, setTaskVerifiedOnly] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
@@ -124,7 +125,14 @@ const HomeApp = () => {
   }, [page, fetchFromAPI]);
 
   const filteredAgents = useMemo(() => {
-    if (!useStaticFallback) return agents;
+    if (!useStaticFallback) {
+      // Task-verified filter is client-side (API doesn't index on it yet).
+      // Applied as a post-filter on whatever the server returned.
+      if (taskVerifiedOnly) {
+        return agents.filter((a) => a.task_conformance && a.task_conformance.passed === true);
+      }
+      return agents;
+    }
     const q = searchTerm.toLowerCase();
     let filtered = agents.filter((agent) =>
       agent.name.toLowerCase().includes(q) ||
@@ -142,10 +150,16 @@ const HomeApp = () => {
     }
     if (conformanceFilter === 'standard') filtered = filtered.filter((a) => a.conformance !== false);
     else if (conformanceFilter === 'non-standard') filtered = filtered.filter((a) => a.conformance === false);
+    if (taskVerifiedOnly) {
+      filtered = filtered.filter((a) => a.task_conformance && a.task_conformance.passed === true);
+    }
     return filtered;
-  }, [useStaticFallback, agents, searchTerm, selectedSkills, conformanceFilter]);
+  }, [useStaticFallback, agents, searchTerm, selectedSkills, conformanceFilter, taskVerifiedOnly]);
 
-  const displayedAgents = useStaticFallback ? filteredAgents : agents;
+  // filteredAgents handles both paths: static-fallback does the full client
+  // filter, live-API path only post-filters on task_verified (everything else
+  // is server-side via API params).
+  const displayedAgents = filteredAgents;
 
   const didInitialUrlSync = useRef(false);
 
@@ -278,6 +292,8 @@ const HomeApp = () => {
       setConformanceFilter={setConformanceFilter}
       healthyOnly={healthyOnly}
       setHealthyOnly={setHealthyOnly}
+      taskVerifiedOnly={taskVerifiedOnly}
+      setTaskVerifiedOnly={setTaskVerifiedOnly}
       selectedAgent={selectedAgent}
       onCloseInspection={handleCloseInspection}
       stats={stats}
@@ -296,6 +312,7 @@ const HomeApp = () => {
           setSelectedSkills([]);
           setConformanceFilter('standard');
           setHealthyOnly(false);
+          setTaskVerifiedOnly(false);
         }}
       />
     </Layout>

--- a/website/src/components/HomeApp.jsx
+++ b/website/src/components/HomeApp.jsx
@@ -66,6 +66,7 @@ const HomeApp = () => {
       skill: skillParam,
       conformance: conformanceFilter !== 'all' ? conformanceFilter : undefined,
       healthy: healthyOnly || undefined,
+      task_verified: taskVerifiedOnly || undefined,
       limit: LIMIT,
       offset,
     });
@@ -75,7 +76,7 @@ const HomeApp = () => {
     if (append) setAgents((prev) => [...prev, ...agentList]);
     else setAgents(agentList);
     setTotal(totalCount);
-  }, [debouncedSearch, selectedSkills, conformanceFilter, healthyOnly]);
+  }, [debouncedSearch, selectedSkills, conformanceFilter, healthyOnly, taskVerifiedOnly]);
 
   useEffect(() => {
     let cancelled = false;
@@ -110,7 +111,7 @@ const HomeApp = () => {
     };
     loadData();
     return () => { cancelled = true; };
-  }, [debouncedSearch, selectedSkills, conformanceFilter, healthyOnly, fetchFromAPI]);
+  }, [debouncedSearch, selectedSkills, conformanceFilter, healthyOnly, taskVerifiedOnly, fetchFromAPI]);
 
   const handleLoadMore = useCallback(async () => {
     const nextPage = page + 1;
@@ -125,14 +126,10 @@ const HomeApp = () => {
   }, [page, fetchFromAPI]);
 
   const filteredAgents = useMemo(() => {
-    if (!useStaticFallback) {
-      // Task-verified filter is client-side (API doesn't index on it yet).
-      // Applied as a post-filter on whatever the server returned.
-      if (taskVerifiedOnly) {
-        return agents.filter((a) => a.task_conformance && a.task_conformance.passed === true);
-      }
-      return agents;
-    }
+    // Live path: server already applied every filter (including task_verified)
+    // before paginating, so no client-side post-filter needed. Static-fallback
+    // path has no server, so the full filter runs below.
+    if (!useStaticFallback) return agents;
     const q = searchTerm.toLowerCase();
     let filtered = agents.filter((agent) =>
       agent.name.toLowerCase().includes(q) ||
@@ -156,10 +153,7 @@ const HomeApp = () => {
     return filtered;
   }, [useStaticFallback, agents, searchTerm, selectedSkills, conformanceFilter, taskVerifiedOnly]);
 
-  // filteredAgents handles both paths: static-fallback does the full client
-  // filter, live-API path only post-filters on task_verified (everything else
-  // is server-side via API params).
-  const displayedAgents = filteredAgents;
+  const displayedAgents = useStaticFallback ? filteredAgents : agents;
 
   const didInitialUrlSync = useRef(false);
 

--- a/website/src/components/Layout.jsx
+++ b/website/src/components/Layout.jsx
@@ -22,12 +22,16 @@ const Layout = ({
     setConformanceFilter,
     healthyOnly,
     setHealthyOnly,
+    taskVerifiedOnly,
+    setTaskVerifiedOnly,
     selectedAgent,
     onCloseInspection,
     stats
 }) => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-    const activeFilterCount = selectedSkills.length + (conformanceFilter !== 'standard' ? 1 : 0);
+    const activeFilterCount = selectedSkills.length
+        + (conformanceFilter !== 'standard' ? 1 : 0)
+        + (taskVerifiedOnly ? 1 : 0);
 
     // Keyboard shortcut: "/" to focus search
     useEffect(() => {
@@ -70,6 +74,8 @@ const Layout = ({
                         setConformanceFilter={setConformanceFilter}
                         healthyOnly={healthyOnly}
                         setHealthyOnly={setHealthyOnly}
+                        taskVerifiedOnly={taskVerifiedOnly}
+                        setTaskVerifiedOnly={setTaskVerifiedOnly}
                     />
                 </div>
 
@@ -131,6 +137,10 @@ const Layout = ({
                             toggleSkillFilter={toggleSkillFilter}
                             conformanceFilter={conformanceFilter}
                             setConformanceFilter={setConformanceFilter}
+                            healthyOnly={healthyOnly}
+                            setHealthyOnly={setHealthyOnly}
+                            taskVerifiedOnly={taskVerifiedOnly}
+                            setTaskVerifiedOnly={setTaskVerifiedOnly}
                             isMobile
                         />
                     </div>

--- a/website/src/components/Sidebar.jsx
+++ b/website/src/components/Sidebar.jsx
@@ -11,6 +11,8 @@ const Sidebar = ({
     setConformanceFilter,
     healthyOnly,
     setHealthyOnly,
+    taskVerifiedOnly,
+    setTaskVerifiedOnly,
     isMobile
 }) => {
     const filterOptions = [
@@ -98,6 +100,24 @@ const Sidebar = ({
                                     <div className="mt-1 text-[11px] text-zinc-500">Hide agents that are down</div>
                                 </div>
                                 <div className={`mt-1 h-2 w-2 rounded-full ${healthyOnly ? 'bg-emerald-500' : 'bg-zinc-700'}`} />
+                            </div>
+                        </button>
+                        <button
+                            onClick={() => setTaskVerifiedOnly(!taskVerifiedOnly)}
+                            className={`
+                                w-full border px-3 py-3 text-left transition-all
+                                ${taskVerifiedOnly
+                                    ? 'border-emerald-500/50 bg-emerald-500/10'
+                                    : 'border-zinc-800 bg-zinc-900/40 hover:border-zinc-700'
+                                }
+                            `}
+                        >
+                            <div className="flex items-start justify-between gap-3">
+                                <div>
+                                    <div className={`text-xs font-mono ${taskVerifiedOnly ? 'text-zinc-100' : 'text-zinc-300'}`}>TASK_VERIFIED</div>
+                                    <div className="mt-1 text-[11px] text-zinc-500">Responded to a real A2A message/send</div>
+                                </div>
+                                <div className={`mt-1 h-2 w-2 rounded-full ${taskVerifiedOnly ? 'bg-emerald-500' : 'bg-zinc-700'}`} />
                             </div>
                         </button>
                     </div>

--- a/website/src/lib/api.js
+++ b/website/src/lib/api.js
@@ -36,7 +36,7 @@ async function fetchAPI(endpoint, options = {}) {
 
 export const api = {
   // Get all agents with optional filtering
-  async getAgents({ skill, capability, author, search, conformance, healthy, limit = 50, offset = 0 } = {}) {
+  async getAgents({ skill, capability, author, search, conformance, healthy, task_verified, limit = 50, offset = 0 } = {}) {
     const params = new URLSearchParams();
     if (skill) params.append('skill', skill);
     if (capability) params.append('capability', capability);
@@ -44,6 +44,7 @@ export const api = {
     if (search) params.append('search', search);
     if (conformance) params.append('conformance', conformance);
     if (healthy !== undefined) params.append('healthy', healthy);
+    if (task_verified !== undefined) params.append('task_verified', task_verified);
     params.append('limit', limit);
     params.append('offset', offset);
 


### PR DESCRIPTION
Closes the gap surfaced in #108: card-health (cheap GET) and task-conformance (real A2A `message/send`) were measured at different times — GET every 30 min, task only at registration. That left the registry showing healthy=true for agents whose POST endpoint had since broken.

This PR makes the task-probe a recurring signal, persists it as a structured field, and surfaces it on the API + listing.

## Changes

- `backend/migrations/versions/007_add_task_conformance.sql` — new columns `task_conformance_category` (CHECK-constrained to the 17-class taxonomy from `smoke_test.py`), `task_conformance_passed`, `task_conformance_checked_at`, `task_conformance_response_ms`.
- `backend/app/smoke_test.py` — return tuple extended to `(category, note, response_ms)`. Accepts a custom UA so worker probes can be distinguished from registration smoke checks in operator logs. New `TASK_PROBE_USER_AGENT = "A2A-Registry-TaskProbe/1.0 (+https://a2aregistry.org)"`.
- `backend/worker.py` — added `run_task_probes()` invoked every `TASK_PROBE_INTERVAL = 48` cycles (~daily at the existing 30-min cycle). Batches of 10 with a 2s pause between, smaller than the GET batches because real POSTs are slower. Dead agents already excluded by the existing throttle.
- `backend/app/repositories.py` — new `update_task_conformance()`; `_row_to_agent_public` now populates the nested `TaskConformance` block.
- `backend/app/models.py` — `TaskConformance` model; `AgentPublic.task_conformance: TaskConformance | None`.
- `backend/app/main.py` — both registration paths now also persist task-conformance at registration time (in addition to the existing `maintainer_notes` write).
- `scripts/check_conformance.py` — new `--probe-tasks` flag calls the same `smoke_test()` helper the worker uses. Single source of truth.
- Website — Sidebar gets a `TASK_VERIFIED` filter alongside `HEALTHY_ONLY`; AgentCard shows a `Task-verified` badge (Zap icon, tooltip with last-check timestamp). Active-filter counter includes the new filter. `displayedAgents` now flows through the unified `filteredAgents` memo so the client-side task filter applies on both the live-API and static-fallback paths.
- `README.md` — added a 'Quality signals' section documenting the three independent signals (`is_healthy`, `conformance`, `task_conformance`) and the User-Agent strings operators will see.

## Local verification

- `pytest backend/tests/ -v` → 114 passed.
- `npm run build` (website) → clean, 103 pages built.
- Ran `smoke_test()` against three live agents from production:
  - `Silas` → `WORKING` (1138ms)
  - `SwarmSync` → `401` (725ms)
  - `GitDealFlow` → `WORKING` (1580ms)

  All three categories valid per the taxonomy; response_ms populated; the new 401-distinct-from-WORKING signal lands as expected.

## Cadence

Daily, not 30-min. `TASK_PROBE_INTERVAL` matches the existing `DEAD_AGENT_CHECK_INTERVAL = 48` so probes and dead-agent revalidation share the same daily 'deep cycle'. POST endpoints can be expensive (LLM calls); hitting them twice an hour would be rude.

## Deployment

Run migration `007_add_task_conformance.sql` against prod before rolling worker. Existing agents land with NULL `task_conformance_*` until the first daily probe.

## Follow-ups

- #128 — passive churn postmortem (the #109 follow-up: registration → last-seen → conformance trajectory → offline-time, no operator survey needed).
- Re-running `check_conformance.py --probe-tasks` against the full registry once this merges will produce fresh numbers for the #108 close-out comment.

## Test plan

- [ ] Apply migration `007_add_task_conformance.sql` in staging
- [ ] Confirm worker daily-cycle log line `task_probe_cycle_done` appears
- [ ] Confirm `/api/agents` response includes `task_conformance` block when present
- [ ] Confirm `Task-verified` badge renders only for `task_conformance.passed === true`
- [ ] Confirm `TASK_VERIFIED` sidebar filter narrows the listing correctly
- [ ] Spot-check a few agents' UA logs to confirm `A2A-Registry-TaskProbe/1.0` shows up on daily probe