### PR TITLE
feat(scripts): passive churn analysis report (#128)

### DIFF
--- a/backend/tests/test_churn_report.py
+++ b/backend/tests/test_churn_report.py
@@ -1,0 +1,201 @@
+"""Tests for scripts/churn_report.py.
+
+We mock the asyncpg connection and feed each view its expected row shape.
+Per-view tests assert the output schema; an end-to-end test asserts the
+top-level JSON keys and markdown rendering.
+"""
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import churn_report as cr  # noqa: E402
+
+
+def _make_conn(fetch_map=None, fetchrow_map=None):
+    """Build a mock asyncpg connection.
+
+    fetch_map / fetchrow_map are dicts keyed by a substring of the query
+    so each view can be addressed independently.
+    """
+    fetch_map = fetch_map or {}
+    fetchrow_map = fetchrow_map or {}
+
+    async def fetch(query, *args):
+        for needle, rows in fetch_map.items():
+            if needle in query:
+                return rows
+        return []
+
+    async def fetchrow(query, *args):
+        for needle, row in fetchrow_map.items():
+            if needle in query:
+                return row
+        return None
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=fetch)
+    conn.fetchrow = AsyncMock(side_effect=fetchrow)
+    conn.execute = AsyncMock(return_value="OK")
+    return conn
+
+
+# ── Per-view tests ──────────────────────────────────────────────────────────
+
+async def test_time_to_first_failure_shape():
+    conn = _make_conn(fetch_map={"days_to_fail": [
+        {"bucket": "0d", "agents": 3},
+        {"bucket": "1d", "agents": 5},
+        {"bucket": "7-29d", "agents": 2},
+    ]})
+    out = await cr.view_time_to_first_failure(conn)
+    assert out["total_agents_with_failure"] == 10
+    assert {b["bucket"] for b in out["buckets"]} == {"0d", "1d", "7-29d"}
+    assert out["small_cohort"] is False
+
+
+async def test_initial_to_final_shape():
+    conn = _make_conn(fetch_map={"initial_category": [
+        {"initial_category": "WORKING", "final_state": "healthy",
+         "final_task_category": "WORKING", "agents": 12},
+        {"initial_category": "404", "final_state": "hidden",
+         "final_task_category": "404", "agents": 4},
+    ]})
+    out = await cr.view_initial_to_final(conn)
+    assert len(out["rows"]) == 2
+    assert out["rows"][0]["initial_category"] == "WORKING"
+    assert out["small_cohort"] is False
+
+
+async def test_recovery_rate_normal():
+    conn = _make_conn(fetchrow_map={"long_fail_streaks": {
+        "agents_with_long_fail_streak": 10,
+        "recovered": 3,
+        "avg_days_to_recover": 4.5,
+        "median_days_to_recover": 3.0,
+    }})
+    out = await cr.view_recovery_rate(conn)
+    assert out["recovery_rate"] == 0.3
+    assert out["avg_days_to_recover"] == 4.5
+    assert out["small_cohort"] is False
+
+
+async def test_recovery_rate_small_cohort_suppressed():
+    conn = _make_conn(fetchrow_map={"long_fail_streaks": {
+        "agents_with_long_fail_streak": 2,
+        "recovered": 1,
+        "avg_days_to_recover": 1.0,
+        "median_days_to_recover": 1.0,
+    }})
+    out = await cr.view_recovery_rate(conn)
+    assert out["small_cohort"] is True
+    assert "recovery_rate" not in out
+    assert cr.SMALL_COHORT_NOTE in out["note"]
+
+
+async def test_conformance_trajectory_shape():
+    conn = _make_conn(fetch_map={"conformance_state": [
+        {"conformance_state": "card_valid", "task_conformance_category": "404",
+         "hidden_agents": 7},
+        {"conformance_state": "card_invalid", "task_conformance_category": None,
+         "hidden_agents": 2},
+    ]})
+    out = await cr.view_conformance_trajectory(conn)
+    assert out["total_hidden"] == 9
+    assert any(r["conformance_state"] == "card_valid" for r in out["rows"])
+
+
+async def test_cohort_survival_suppresses_small_cohorts():
+    conn = _make_conn(fetch_map={"cohort_month": [
+        {"cohort_month": dt.date(2026, 1, 1), "cohort_size": 12,
+         "alive_1d": 11, "alive_7d": 9, "alive_30d": 7, "alive_90d": 5},
+        {"cohort_month": dt.date(2026, 2, 1), "cohort_size": 3,
+         "alive_1d": 2, "alive_7d": 1, "alive_30d": 1, "alive_90d": 0},
+    ]})
+    out = await cr.view_cohort_survival(conn)
+    big, small = out["cohorts"]
+    assert big["alive_1d"] == 11
+    assert small["alive_1d"] is None
+    assert small["note"] == cr.SMALL_COHORT_NOTE
+
+
+# ── End-to-end ──────────────────────────────────────────────────────────────
+
+async def test_run_report_returns_all_views():
+    conn = _make_conn(
+        fetch_map={
+            "days_to_fail": [{"bucket": "0d", "agents": 1}],
+            "initial_category": [],
+            "conformance_state": [],
+            "cohort_month": [],
+        },
+        fetchrow_map={"long_fail_streaks": {
+            "agents_with_long_fail_streak": 0,
+            "recovered": 0,
+            "avg_days_to_recover": None,
+            "median_days_to_recover": None,
+        }},
+    )
+    report = await cr.run_report(conn)
+    assert set(report.keys()) == {
+        "time_to_first_failure",
+        "initial_to_final_state",
+        "recovery_rate",
+        "conformance_trajectory",
+        "cohort_survival",
+    }
+    conn.execute.assert_awaited_with("SET TRANSACTION READ ONLY")
+    # JSON-serializable.
+    json.dumps(report, default=str)
+
+
+async def test_markdown_renders_all_sections():
+    conn = _make_conn(
+        fetch_map={
+            "days_to_fail": [{"bucket": "0d", "agents": 6}],
+            "initial_category": [
+                {"initial_category": "WORKING", "final_state": "healthy",
+                 "final_task_category": "WORKING", "agents": 9},
+            ],
+            "conformance_state": [
+                {"conformance_state": "card_valid",
+                 "task_conformance_category": "404", "hidden_agents": 6},
+            ],
+            "cohort_month": [
+                {"cohort_month": dt.date(2026, 1, 1), "cohort_size": 8,
+                 "alive_1d": 7, "alive_7d": 5, "alive_30d": 3, "alive_90d": 1},
+            ],
+        },
+        fetchrow_map={"long_fail_streaks": {
+            "agents_with_long_fail_streak": 10,
+            "recovered": 4,
+            "avg_days_to_recover": 2.0,
+            "median_days_to_recover": 2.0,
+        }},
+    )
+    report = await cr.run_report(conn)
+    md = cr.render_markdown(report)
+    for section in (
+        "1. Time-to-first-failure",
+        "2. Initial-category",
+        "3. Recovery rate",
+        "4. Conformance trajectory",
+        "5. Cohort survival",
+    ):
+        assert section in md
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_format_cell_handles_none_and_floats():
+    assert cr._fmt_cell(None) == "—"
+    assert cr._fmt_cell(1.2345) == "1.23"
+    assert cr._fmt_cell("x") == "x"

--- a/scripts/churn_report.py
+++ b/scripts/churn_report.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Passive churn analysis for the A2A Registry. Reads directly from the
+agents + health_checks tables and emits five views as JSON (default) or
+a markdown table dump.
+
+Usage:
+    uv run scripts/churn_report.py
+    uv run scripts/churn_report.py --format=markdown
+
+The script opens a read-only transaction and runs no writes/DDL. It uses
+the same DATABASE_URL_OVERRIDE / DB_* env vars as the backend app.
+
+Issue: #128 (follow-up to #109).
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
+
+from app.config import settings  # noqa: E402
+
+MIN_COHORT_SIZE = 5
+SMALL_COHORT_NOTE = f"n<{MIN_COHORT_SIZE} (suppressed)"
+
+
+# ── Queries ─────────────────────────────────────────────────────────────────
+# All queries are read-only. The connection is opened with a READ ONLY
+# transaction wrapper, so accidental writes would error out anyway.
+
+Q_TIME_TO_FIRST_FAILURE = """
+SELECT
+    CASE
+        WHEN days_to_fail < 1 THEN '0d'
+        WHEN days_to_fail < 2 THEN '1d'
+        WHEN days_to_fail < 7 THEN '2-6d'
+        WHEN days_to_fail < 30 THEN '7-29d'
+        ELSE '30d+'
+    END AS bucket,
+    COUNT(*) AS agents
+FROM (
+    SELECT
+        a.id,
+        EXTRACT(EPOCH FROM (MIN(hc.checked_at) - a.created_at)) / 86400.0
+            AS days_to_fail
+    FROM agents a
+    JOIN health_checks hc
+      ON hc.agent_id = a.id AND hc.success = false
+    GROUP BY a.id, a.created_at
+) t
+WHERE days_to_fail IS NOT NULL AND days_to_fail >= 0
+GROUP BY bucket
+ORDER BY
+    CASE bucket
+        WHEN '0d' THEN 0
+        WHEN '1d' THEN 1
+        WHEN '2-6d' THEN 2
+        WHEN '7-29d' THEN 3
+        ELSE 4
+    END;
+"""
+
+# (2) initial-category → final-state pivot.
+# `maintainer_notes` is free-form text; the leading token before the first
+# period or whitespace is the smoke-test category for agents registered
+# post-#126. For older rows it's NULL — we surface that as "unknown" rather
+# than dropping the row.
+Q_INITIAL_TO_FINAL = """
+SELECT
+    COALESCE(
+        NULLIF(split_part(COALESCE(maintainer_notes, ''), '.', 1), ''),
+        'unknown'
+    ) AS initial_category,
+    CASE
+        WHEN hidden THEN 'hidden'
+        WHEN task_conformance_passed IS TRUE THEN 'healthy'
+        WHEN task_conformance_passed IS FALSE THEN 'failing'
+        ELSE 'unchecked'
+    END AS final_state,
+    task_conformance_category AS final_task_category,
+    COUNT(*) AS agents
+FROM agents
+GROUP BY initial_category, final_state, final_task_category
+ORDER BY initial_category, final_state, final_task_category;
+"""
+
+# (3) recovery rate. Agents that hit a run of >=10 consecutive failed
+# health checks, then later had a successful one. We compute "consecutive
+# failures" via the classic gaps-and-islands trick.
+Q_RECOVERY_RATE = """
+WITH ordered AS (
+    SELECT
+        agent_id,
+        checked_at,
+        success,
+        ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY checked_at)
+            AS rn,
+        ROW_NUMBER() OVER (
+            PARTITION BY agent_id, success ORDER BY checked_at
+        ) AS rn_success
+    FROM health_checks
+),
+streaks AS (
+    SELECT
+        agent_id,
+        success,
+        rn - rn_success AS streak_id,
+        MIN(checked_at) AS streak_start,
+        MAX(checked_at) AS streak_end,
+        COUNT(*) AS streak_len
+    FROM ordered
+    GROUP BY agent_id, success, rn - rn_success
+),
+long_fail_streaks AS (
+    SELECT *
+    FROM streaks
+    WHERE success = false AND streak_len >= 10
+),
+recoveries AS (
+    SELECT
+        lfs.agent_id,
+        lfs.streak_end AS failed_until,
+        MIN(hc.checked_at) AS recovered_at
+    FROM long_fail_streaks lfs
+    LEFT JOIN health_checks hc
+      ON hc.agent_id = lfs.agent_id
+     AND hc.success = true
+     AND hc.checked_at > lfs.streak_end
+    GROUP BY lfs.agent_id, lfs.streak_end
+)
+SELECT
+    COUNT(*) AS agents_with_long_fail_streak,
+    COUNT(recovered_at) AS recovered,
+    AVG(EXTRACT(EPOCH FROM (recovered_at - failed_until)) / 86400.0)
+        AS avg_days_to_recover,
+    percentile_disc(0.5) WITHIN GROUP (
+        ORDER BY EXTRACT(EPOCH FROM (recovered_at - failed_until)) / 86400.0
+    ) AS median_days_to_recover
+FROM recoveries;
+"""
+
+# (4) conformance trajectory for hidden agents. Did `conformance` flip
+# false before the agent went offline, or was the card still valid?
+# We approximate "went offline" as the first day in the agent's most
+# recent failure streak. Since we don't have a historical conformance
+# log, we report the *current* conformance for hidden agents — this is
+# a snapshot, not a time series. The maintainer can read it as
+# "of the agents that are currently hidden, how many also have a
+# broken/missing card vs. a valid card that's just unreachable."
+Q_CONFORMANCE_TRAJECTORY = """
+SELECT
+    CASE
+        WHEN conformance IS TRUE THEN 'card_valid'
+        WHEN conformance IS FALSE THEN 'card_invalid'
+        ELSE 'card_unchecked'
+    END AS conformance_state,
+    task_conformance_category,
+    COUNT(*) AS hidden_agents
+FROM agents
+WHERE hidden = true
+GROUP BY conformance_state, task_conformance_category
+ORDER BY conformance_state, task_conformance_category;
+"""
+
+# (5) cohort survival by registration month. "Still healthy at N days"
+# = the agent had a successful health check within the [N-1, N+1] day
+# window post-registration. Because the worker prunes >90d of
+# health_checks history, the 90d column is only meaningful for cohorts
+# registered <90 days ago AND with surviving health rows.
+Q_COHORT_SURVIVAL = """
+WITH cohorts AS (
+    SELECT
+        date_trunc('month', created_at)::date AS cohort_month,
+        id,
+        created_at
+    FROM agents
+),
+checks_with_age AS (
+    SELECT
+        c.cohort_month,
+        c.id,
+        EXTRACT(EPOCH FROM (hc.checked_at - c.created_at)) / 86400.0
+            AS age_days,
+        hc.success
+    FROM cohorts c
+    LEFT JOIN health_checks hc ON hc.agent_id = c.id
+),
+survival AS (
+    SELECT
+        cohort_month,
+        id,
+        bool_or(success AND age_days BETWEEN 0 AND 2)   AS alive_1d,
+        bool_or(success AND age_days BETWEEN 0 AND 8)   AS alive_7d,
+        bool_or(success AND age_days BETWEEN 0 AND 31)  AS alive_30d,
+        bool_or(success AND age_days BETWEEN 0 AND 91)  AS alive_90d
+    FROM checks_with_age
+    GROUP BY cohort_month, id
+)
+SELECT
+    cohort_month,
+    COUNT(*) AS cohort_size,
+    SUM(CASE WHEN alive_1d  THEN 1 ELSE 0 END) AS alive_1d,
+    SUM(CASE WHEN alive_7d  THEN 1 ELSE 0 END) AS alive_7d,
+    SUM(CASE WHEN alive_30d THEN 1 ELSE 0 END) AS alive_30d,
+    SUM(CASE WHEN alive_90d THEN 1 ELSE 0 END) AS alive_90d
+FROM survival
+GROUP BY cohort_month
+ORDER BY cohort_month;
+"""
+
+
+# ── View runners ────────────────────────────────────────────────────────────
+
+async def view_time_to_first_failure(conn: asyncpg.Connection) -> dict[str, Any]:
+    rows = await conn.fetch(Q_TIME_TO_FIRST_FAILURE)
+    buckets = [{"bucket": r["bucket"], "agents": r["agents"]} for r in rows]
+    total = sum(b["agents"] for b in buckets)
+    return {
+        "description": "Days from registration to first failed health check.",
+        "total_agents_with_failure": total,
+        "buckets": buckets,
+        "small_cohort": total < MIN_COHORT_SIZE,
+    }
+
+
+async def view_initial_to_final(conn: asyncpg.Connection) -> dict[str, Any]:
+    rows = await conn.fetch(Q_INITIAL_TO_FINAL)
+    pivot = [
+        {
+            "initial_category": r["initial_category"],
+            "final_state": r["final_state"],
+            "final_task_category": r["final_task_category"],
+            "agents": r["agents"],
+        }
+        for r in rows
+    ]
+    return {
+        "description": (
+            "Initial smoke-test category (from maintainer_notes, parsed) "
+            "pivoted against current state. 'unknown' covers rows registered "
+            "before #126 backfilled the structured category."
+        ),
+        "rows": pivot,
+        "small_cohort": sum(p["agents"] for p in pivot) < MIN_COHORT_SIZE,
+    }
+
+
+async def view_recovery_rate(conn: asyncpg.Connection) -> dict[str, Any]:
+    row = await conn.fetchrow(Q_RECOVERY_RATE)
+    n = row["agents_with_long_fail_streak"] if row else 0
+    if n < MIN_COHORT_SIZE:
+        return {
+            "description": (
+                "Of agents that hit >=10 consecutive failed health checks, "
+                "what fraction later had a successful check, and how long "
+                "did recovery take."
+            ),
+            "agents_with_long_fail_streak": n,
+            "note": SMALL_COHORT_NOTE,
+            "small_cohort": True,
+        }
+    recovered = row["recovered"]
+    return {
+        "description": (
+            "Of agents that hit >=10 consecutive failed health checks, "
+            "what fraction later had a successful check, and how long "
+            "did recovery take."
+        ),
+        "agents_with_long_fail_streak": n,
+        "recovered": recovered,
+        "recovery_rate": (recovered / n) if n else None,
+        "avg_days_to_recover": (
+            float(row["avg_days_to_recover"])
+            if row["avg_days_to_recover"] is not None
+            else None
+        ),
+        "median_days_to_recover": (
+            float(row["median_days_to_recover"])
+            if row["median_days_to_recover"] is not None
+            else None
+        ),
+        "small_cohort": False,
+    }
+
+
+async def view_conformance_trajectory(conn: asyncpg.Connection) -> dict[str, Any]:
+    rows = await conn.fetch(Q_CONFORMANCE_TRAJECTORY)
+    breakdown = [
+        {
+            "conformance_state": r["conformance_state"],
+            "task_conformance_category": r["task_conformance_category"],
+            "hidden_agents": r["hidden_agents"],
+        }
+        for r in rows
+    ]
+    total = sum(b["hidden_agents"] for b in breakdown)
+    return {
+        "description": (
+            "Among currently-hidden agents, the split between cards that "
+            "are still schema-valid (endpoint just stopped responding) and "
+            "cards that became invalid. Snapshot, not a time series — the "
+            "registry does not log historical conformance flips."
+        ),
+        "total_hidden": total,
+        "rows": breakdown,
+        "small_cohort": total < MIN_COHORT_SIZE,
+    }
+
+
+async def view_cohort_survival(conn: asyncpg.Connection) -> dict[str, Any]:
+    rows = await conn.fetch(Q_COHORT_SURVIVAL)
+    cohorts = []
+    for r in rows:
+        size = r["cohort_size"]
+        too_small = size < MIN_COHORT_SIZE
+        cohorts.append({
+            "cohort_month": r["cohort_month"].isoformat() if r["cohort_month"] else None,
+            "cohort_size": size,
+            "alive_1d": r["alive_1d"] if not too_small else None,
+            "alive_7d": r["alive_7d"] if not too_small else None,
+            "alive_30d": r["alive_30d"] if not too_small else None,
+            "alive_90d": r["alive_90d"] if not too_small else None,
+            "note": SMALL_COHORT_NOTE if too_small else None,
+        })
+    return {
+        "description": (
+            "Per registration-month cohort, count of agents with at least "
+            "one successful health check within the first 1/7/30/90 days. "
+            "90d column is limited by the 90-day health-check retention."
+        ),
+        "cohorts": cohorts,
+    }
+
+
+VIEWS = [
+    ("time_to_first_failure", view_time_to_first_failure),
+    ("initial_to_final_state", view_initial_to_final),
+    ("recovery_rate", view_recovery_rate),
+    ("conformance_trajectory", view_conformance_trajectory),
+    ("cohort_survival", view_cohort_survival),
+]
+
+
+async def run_report(conn: asyncpg.Connection) -> dict[str, Any]:
+    await conn.execute("SET TRANSACTION READ ONLY")
+    out: dict[str, Any] = {}
+    for name, fn in VIEWS:
+        out[name] = await fn(conn)
+    return out
+
+
+# ── Output formatting ───────────────────────────────────────────────────────
+
+def _fmt_cell(v: Any) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:.2f}"
+    return str(v)
+
+
+def _md_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
+    if not rows:
+        return "_no rows_\n"
+    header = "| " + " | ".join(columns) + " |"
+    sep = "| " + " | ".join("---" for _ in columns) + " |"
+    body = "\n".join(
+        "| " + " | ".join(_fmt_cell(r.get(c)) for c in columns) + " |"
+        for r in rows
+    )
+    return f"{header}\n{sep}\n{body}\n"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    parts: list[str] = ["# A2A Registry Churn Report\n"]
+
+    v = report["time_to_first_failure"]
+    parts.append("## 1. Time-to-first-failure\n")
+    parts.append(v["description"] + "\n")
+    parts.append(f"_Total agents with at least one failure: {v['total_agents_with_failure']}_\n")
+    parts.append(_md_table(v["buckets"], ["bucket", "agents"]))
+
+    v = report["initial_to_final_state"]
+    parts.append("\n## 2. Initial-category → final-state pivot\n")
+    parts.append(v["description"] + "\n")
+    parts.append(_md_table(
+        v["rows"],
+        ["initial_category", "final_state", "final_task_category", "agents"],
+    ))
+
+    v = report["recovery_rate"]
+    parts.append("\n## 3. Recovery rate (>=10 consecutive failures)\n")
+    parts.append(v["description"] + "\n")
+    if v.get("small_cohort"):
+        parts.append(f"_{v.get('note', SMALL_COHORT_NOTE)} "
+                     f"(n={v['agents_with_long_fail_streak']})_\n")
+    else:
+        parts.append(_md_table([v], [
+            "agents_with_long_fail_streak",
+            "recovered",
+            "recovery_rate",
+            "avg_days_to_recover",
+            "median_days_to_recover",
+        ]))
+
+    v = report["conformance_trajectory"]
+    parts.append("\n## 4. Conformance trajectory (currently-hidden agents)\n")
+    parts.append(v["description"] + "\n")
+    parts.append(f"_Total hidden: {v['total_hidden']}_\n")
+    parts.append(_md_table(
+        v["rows"],
+        ["conformance_state", "task_conformance_category", "hidden_agents"],
+    ))
+
+    v = report["cohort_survival"]
+    parts.append("\n## 5. Cohort survival by registration month\n")
+    parts.append(v["description"] + "\n")
+    parts.append(_md_table(
+        v["cohorts"],
+        ["cohort_month", "cohort_size",
+         "alive_1d", "alive_7d", "alive_30d", "alive_90d", "note"],
+    ))
+
+    return "\n".join(parts)
+
+
+# ── Entrypoint ──────────────────────────────────────────────────────────────
+
+async def main(fmt: str) -> int:
+    dsn = settings.database_url
+    conn = await asyncpg.connect(dsn)
+    try:
+        report = await run_report(conn)
+    finally:
+        await conn.close()
+
+    if fmt == "markdown":
+        print(render_markdown(report))
+    else:
+        print(json.dumps(report, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(fmt=args.format)))


### PR DESCRIPTION
Closes #128 (follow-up to #109).

Adds `scripts/churn_report.py` — a read-only DB query script that emits the five churn-analysis views from issue #128 as JSON (default) or markdown (`--format=markdown`). No new endpoint; runnable from a maintainer terminal with the same `DATABASE_URL_OVERRIDE` / `DB_*` env vars the backend uses.

## Views

1. **`time_to_first_failure`** — Days from registration to first failed health check, bucketed (0d / 1d / 2-6d / 7-29d / 30d+). Answers "how fast do agents start failing after they're registered?"
2. **`initial_to_final_state`** — Pivots the initial smoke-test category (parsed from `maintainer_notes`) against current state (`healthy` / `failing` / `hidden` / `unchecked`) and current `task_conformance_category`. Pre-#126 rows surface as `initial_category=unknown`. Answers "do broken-on-registration agents tend to stay broken, or do operators fix them?"
3. **`recovery_rate`** — Of agents that hit >=10 consecutive failed health checks (gaps-and-islands), what fraction had a successful check after, and how long did recovery take (avg + median days). Suppressed with `n<5 (suppressed)` if the cohort is too small.
4. **`conformance_trajectory`** — For currently-hidden agents, the split between `card_valid` / `card_invalid` / `card_unchecked` crossed with `task_conformance_category`. **Snapshot, not a time series** — the registry doesn't log historical conformance flips, and that limitation is called out in the view's `description` field.
5. **`cohort_survival`** — Per registration-month cohort, count of agents with at least one successful health check inside the first 1 / 7 / 30 / 90 days. Per-cohort `n<5` is suppressed (cells become `null` with a `note`).

## Safety

- All queries are read-only. The script opens a connection and immediately runs `SET TRANSACTION READ ONLY` before any view executes — accidental writes would error out.
- No DDL.
- Uses `asyncpg.connect` directly (not the app's pool) so it has no side effects on a running backend.
- 90d retention on `health_checks` is acknowledged in view (5)'s description.

## Output

- **JSON** is the default and source of truth. Each top-level key is a view; each view includes a `description` field and (where applicable) `small_cohort` / `note` markers.
- **Markdown** is derived from the same dict via `render_markdown()` — a thin formatter, easy to swap.

## Tests

`backend/tests/test_churn_report.py` — 9 tests:
- One per view asserting output shape from a mocked asyncpg connection.
- Small-cohort suppression test (recovery + survival).
- End-to-end `run_report()` asserting all five keys + that `SET TRANSACTION READ ONLY` ran.
- Markdown rendering smoke test.

Mocks asyncpg via `unittest.mock`, matching the existing test infra (no real Postgres in CI — see `backend/tests/conftest.py`).

## Test plan

- [x] `uv run --extra dev pytest tests/` — 123 passed
- [x] `uv run --extra dev ruff check scripts/churn_report.py tests/test_churn_report.py` — clean
- [ ] Manual run against staging/prod once maintainer's creds are loaded — flip to ready and update PR body with headline numbers.