### PR TITLE
fix: health 500 (#134) + PUT body-ignored (#133) + chat split-host 502 (#135)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -590,6 +590,18 @@ def _is_private_url(url: str) -> bool:
         return host in _BLOCKED_HOSTS or any(host.endswith(s) for s in _BLOCKED_SUFFIXES)
 
 
+def _client_target_url(client) -> Optional[str]:
+    """Best-effort: the URL the SDK client's transport will POST to.
+
+    Used to re-run the SSRF guard against the actual send target after the
+    card is (re)fetched at chat time. Returns None if the transport URL can't
+    be determined (in which case the caller should fall back to the stored,
+    already-validated agent.url guard rather than send blind).
+    """
+    transport = getattr(client, "_transport", None) or getattr(client, "transport", None)
+    return getattr(transport, "url", None) if transport else None
+
+
 def _extract_text_from_parts(parts) -> str:
     """Join text content from a list of Part messages."""
     return "".join(p.text for p in parts if p.text)
@@ -668,6 +680,21 @@ async def chat_with_agent(agent_id: UUID, body: ChatRequest, request: Request):
                 ClientConfig(httpx_client=http_client, streaming=False),
             )
             client = factory.create(parse_agent_card(card_dict))
+
+            # SSRF guard on the ACTUAL send target. The stored agent.url was
+            # checked above, but #135 refetches the card at chat time, so the
+            # transport may target a different (freshly parsed) url. Re-check it
+            # so a card that rotated to a private/internal address (127.0.0.1,
+            # the GCP metadata host, etc.) can't be used to pivot.
+            target_url = _client_target_url(client)
+            if target_url and _is_private_url(target_url):
+                elapsed_ms = int((time.monotonic() - start) * 1000)
+                await health_repo.create(
+                    agent_id, 400, elapsed_ms, False,
+                    "Agent endpoint is not publicly reachable", source='chat',
+                )
+                raise HTTPException(status_code=400, detail="Agent endpoint is not publicly reachable")
+
             send_request = SendMessageRequest(message=message)
             response_text = ""
             async for event in client.send_message(send_request):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -402,8 +402,11 @@ async def update_agent(agent_id: UUID, request: Request):
     """
     Re-fetch and update an agent's metadata from its wellKnownURI.
 
-    Verifies ownership by fetching the wellKnownURI and updating all fields
-    from the live agent card.
+    By default re-fetches the agent's current wellKnownURI. To point the agent
+    at a new discovery URL (e.g. its old host rotated or 404s), send a JSON body
+    `{"wellKnownURI": "https://new-host/.well-known/agent-card.json"}`. The new
+    URL is fetched, validated, and persisted on success. With no body the
+    existing URI is used (backward compatible).
     """
     track_api_query("PUT /agents/{id}", agent_id=str(agent_id))
 
@@ -412,7 +415,42 @@ async def update_agent(agent_id: UUID, request: Request):
     if not existing:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    well_known_uri = str(existing.wellKnownURI)
+    # Optionally accept a new wellKnownURI from the request body. Tolerate an
+    # absent/empty/non-JSON body so a plain PUT (re-fetch existing) still works.
+    new_uri = None
+    if request.headers.get("content-type", "").startswith("application/json"):
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if isinstance(body, dict):
+            new_uri = body.get("wellKnownURI") or None
+
+    existing_uri = str(existing.wellKnownURI)
+    if new_uri and str(new_uri) != existing_uri:
+        well_known_uri = str(new_uri)
+        uri_errors = validate_well_known_uri(well_known_uri)
+        if uri_errors:
+            raise HTTPException(status_code=400, detail="; ".join(uri_errors))
+
+        # Don't let a URI change collide with a *different* agent's record.
+        uri_owner = await agent_repo.get_by_well_known_uri(well_known_uri)
+        if uri_owner and uri_owner.id != agent_id:
+            raise HTTPException(
+                status_code=409,
+                detail=f"That wellKnownURI is already registered to a different agent (id={uri_owner.id}).",
+            )
+        hostname = urlparse(well_known_uri).hostname or ""
+        if hostname:
+            host_owner = await agent_repo.get_by_host(hostname)
+            if host_owner and host_owner.id != agent_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"An agent from this host is already registered: '{host_owner.name}' (id={host_owner.id}).",
+                )
+    else:
+        well_known_uri = existing_uri
+
     agent_card, error = await fetch_agent_card(well_known_uri)
     if error:
         raise HTTPException(status_code=400, detail=f"Failed to fetch agent card: {error}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from uuid import UUID
 import httpx
 import structlog
 from a2a.client import ClientConfig, ClientFactory
+from a2a.client.card_resolver import parse_agent_card
 from a2a.types import Message, Part, Role, SendMessageRequest, Task, TaskState
 from fastapi import APIRouter, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -646,16 +647,27 @@ async def chat_with_agent(agent_id: UUID, body: ChatRequest, request: Request):
     health_repo = HealthCheckRepository(db)
     start = time.monotonic()
     try:
+        # Build the client from the agent's *card*, not the wellKnownURI host.
+        # Many agents publish their card on a public domain but run the actual
+        # A2A handler elsewhere (Cloudflare Workers, etc.); the card's `url`
+        # (mapped by parse_agent_card into supportedInterfaces[0].url) is the
+        # real endpoint. Deriving the base from the wellKnownURI host instead
+        # sent JSON-RPC POSTs to the wrong host and 502'd (#135).
+        #
+        # The card is refetched from the agent's stored, already-validated
+        # wellKnownURI — never from request-controlled input.
+        card_dict, card_error = await fetch_agent_card(str(agent.wellKnownURI))
+        if card_error or card_dict is None:
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+            detail = f"Could not load agent card: {card_error or 'no data'}"
+            await health_repo.create(agent_id, 502, elapsed_ms, False, detail, source='chat')
+            raise HTTPException(status_code=502, detail=detail)
+
         async with httpx.AsyncClient(timeout=30.0) as http_client:
-            parsed = urlparse(str(agent.wellKnownURI))
-            agent_base_url = f"{parsed.scheme}://{parsed.netloc}"
-            card_path = parsed.path or None
             factory = ClientFactory(
                 ClientConfig(httpx_client=http_client, streaming=False),
             )
-            client = await factory.create_from_url(
-                agent_base_url, relative_card_path=card_path,
-            )
+            client = factory.create(parse_agent_card(card_dict))
             send_request = SendMessageRequest(message=message)
             response_text = ""
             async for event in client.send_message(send_request):
@@ -682,6 +694,10 @@ async def chat_with_agent(agent_id: UUID, body: ChatRequest, request: Request):
         elapsed_ms = int((time.monotonic() - start) * 1000)
         await health_repo.create(agent_id, 502, elapsed_ms, False, "Agent unreachable", source='chat')
         raise HTTPException(status_code=502, detail=f"Agent unreachable: {exc}")
+    except HTTPException:
+        # Already-formed HTTP errors (e.g. card-load failure above) carry their
+        # own status/detail and a health row was already recorded — re-raise as-is.
+        raise
     except Exception:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         logger.exception("chat_proxy_error", agent_id=str(agent_id))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -591,12 +591,13 @@ def _is_private_url(url: str) -> bool:
 
 
 def _client_target_url(client) -> Optional[str]:
-    """Best-effort: the URL the SDK client's transport will POST to.
+    """The URL the SDK client's transport will POST to, or None if it can't be
+    determined.
 
-    Used to re-run the SSRF guard against the actual send target after the
-    card is (re)fetched at chat time. Returns None if the transport URL can't
-    be determined (in which case the caller should fall back to the stored,
-    already-validated agent.url guard rather than send blind).
+    Used to re-run the SSRF guard against the actual send target after the card
+    is (re)fetched at chat time. Callers MUST fail closed on None: if we can't
+    read the target a future SDK change could hide from us, we must not send,
+    rather than fall back to a stale guard.
     """
     transport = getattr(client, "_transport", None) or getattr(client, "transport", None)
     return getattr(transport, "url", None) if transport else None
@@ -686,8 +687,12 @@ async def chat_with_agent(agent_id: UUID, body: ChatRequest, request: Request):
             # transport may target a different (freshly parsed) url. Re-check it
             # so a card that rotated to a private/internal address (127.0.0.1,
             # the GCP metadata host, etc.) can't be used to pivot.
+            #
+            # Fail closed: if we can't read the actual target (None), reject
+            # rather than send — a future SDK that hides the transport url must
+            # not silently bypass this guard.
             target_url = _client_target_url(client)
-            if target_url and _is_private_url(target_url):
+            if target_url is None or _is_private_url(target_url):
                 elapsed_ms = int((time.monotonic() - start) * 1000)
                 await health_repo.create(
                     agent_id, 400, elapsed_ms, False,

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -532,9 +532,13 @@ class HealthCheckRepository:
 
     async def get_health_status(self, agent_id: UUID) -> Optional[HealthStatus]:
         """Get current health status for an agent (last 24 hours)"""
+        # Note: don't SELECT $1 here. Using the same placeholder as both a bare
+        # SELECT value (inferred as text) and `WHERE agent_id = $1` (inferred as
+        # uuid) makes asyncpg fail with "inconsistent types deduced for
+        # parameter $1: uuid versus text". agent_id is already in scope, so just
+        # pass it through to the result.
         query = """
             SELECT
-                $1 as agent_id,
                 COUNT(*) FILTER (WHERE success = true) > 0 as is_healthy,
                 COALESCE(
                     COUNT(*) FILTER (WHERE success = true)::float / NULLIF(COUNT(*), 0) * 100,
@@ -557,7 +561,7 @@ class HealthCheckRepository:
             return None
 
         return HealthStatus(
-            agent_id=row["agent_id"],
+            agent_id=agent_id,
             is_healthy=row["is_healthy"],
             uptime_percentage=row["uptime_percentage"],
             avg_response_time_ms=row["avg_response_time_ms"],

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -336,28 +336,30 @@ class AgentRepository:
         """Update an existing agent's metadata from a re-fetched agent card"""
         query = """
             UPDATE agents SET
-                protocol_version = $1,
-                name = $2,
-                description = $3,
-                author = $4,
-                url = $5,
-                version = $6,
-                provider = $7,
-                documentation_url = $8,
-                capabilities = $9,
-                default_input_modes = $10,
-                default_output_modes = $11,
-                skills = $12,
-                icon_url = $13,
-                supports_authenticated_extended_card = $14,
-                security_requirements = $15,
-                security_schemes = $16,
+                well_known_uri = $1,
+                protocol_version = $2,
+                name = $3,
+                description = $4,
+                author = $5,
+                url = $6,
+                version = $7,
+                provider = $8,
+                documentation_url = $9,
+                capabilities = $10,
+                default_input_modes = $11,
+                default_output_modes = $12,
+                skills = $13,
+                icon_url = $14,
+                supports_authenticated_extended_card = $15,
+                security_requirements = $16,
+                security_schemes = $17,
                 updated_at = NOW()
-            WHERE id = $17 AND hidden = false
+            WHERE id = $18 AND hidden = false
             RETURNING *
         """
         row = await self.db.fetchrow(
             query,
+            str(agent.wellKnownURI),
             agent.protocolVersion,
             agent.name,
             agent.description,

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -814,6 +814,9 @@ def test_chat_targets_card_url_not_well_known_host(client):
 
     fake_client = MagicMock()
     fake_client.send_message = MagicMock(return_value=_events())
+    # The SSRF guard reads the transport url; give it the real (public) target.
+    fake_client._transport = MagicMock()
+    fake_client._transport.url = "https://paki-api.elfresonero.workers.dev/a2a"
 
     captured = {}
 
@@ -835,12 +838,58 @@ def test_chat_targets_card_url_not_well_known_host(client):
     assert response.json()["response"] == "hi from worker"
     # The card was refetched from the agent's stored wellKnownURI, not request input.
     mock_fetch.assert_called_once_with("https://cesaryague.es/.well-known/agent.json")
+    # Crisp old-vs-new signal: the fix builds the client via factory.create(card).
+    # The old code used factory.create_from_url and never called create(), so
+    # `captured` stays empty against the pre-fix handler.
+    assert "card" in captured, "client must be built via factory.create(parsed_card)"
     # The client was built from the parsed card whose endpoint is the worker.
     parsed_card = captured["card"]
     iface = (getattr(parsed_card, "supported_interfaces", None)
              or getattr(parsed_card, "supportedInterfaces", None))
     assert iface, "parsed card has no supported interface url"
     assert iface[0].url == "https://paki-api.elfresonero.workers.dev/a2a"
+
+
+def test_chat_rejects_private_card_url_after_refetch(client):
+    """SSRF guard on the actual send target: even when stored agent.url and the
+    wellKnownURI are public, a freshly fetched card whose url points at a
+    private/internal host must be rejected before any message is sent."""
+    from unittest.mock import MagicMock
+
+    # Stored url is public (passes the first guard), but the refetched card
+    # points the A2A endpoint at loopback.
+    private_card = {**MOCK_AGENT_CARD, "url": "http://127.0.0.1/a2a"}
+    existing = _make_agent_public(
+        wellKnownURI="https://public-host.example/.well-known/agent.json",
+        url="https://public-host.example/a2a",
+    )
+
+    fake_client = MagicMock()
+    # If the guard fails to fire, send_message would be hit — make that loud.
+    fake_client.send_message = MagicMock(side_effect=AssertionError("send_message must not be called"))
+
+    def fake_create(card):
+        c = MagicMock()
+        c._transport = MagicMock()
+        c._transport.url = "http://127.0.0.1/a2a"
+        c.send_message = fake_client.send_message
+        return c
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.HealthCheckRepository") as mock_health_cls, \
+         patch("app.main.fetch_agent_card", return_value=(private_card, None)), \
+         patch("app.main.ClientFactory") as mock_factory_cls:
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        mock_health_cls.return_value.create = AsyncMock(return_value=None)
+        mock_factory_cls.return_value.create = fake_create
+
+        response = client.post(f"/agents/{MOCK_UUID}/chat", json={"message": "hi"})
+
+    # Rejected before send, and NOT relabeled as a generic 502 by the broad handler.
+    assert response.status_code == 400, response.text
+    assert "not publicly reachable" in response.json()["detail"]
+    fake_client.send_message.assert_not_called()
 
 
 def test_parsed_split_host_card_resolves_transport_to_card_url():

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -270,6 +270,108 @@ def test_update_agent_fetch_fails(client):
     assert "Timeout" in response.json()["detail"]
 
 
+# --- #133: PUT must honor a wellKnownURI in the request body ----------------
+#
+# update_agent used to read wellKnownURI only from the existing DB row and
+# ignore the request body, so an agent stuck on a dead URL could never be
+# pointed at a live one — every PUT re-fetched the dead URL and 404'd. These
+# tests pin that a body wellKnownURI is fetched/validated/persisted, while a
+# no-body PUT still re-fetches the existing URI (backward compatible).
+
+NEW_URI = "https://new-live-host.example/.well-known/agent-card.json"
+
+
+def test_update_agent_uses_body_well_known_uri(client):
+    """PUT with a new wellKnownURI fetches and persists the NEW url, not the old one."""
+    existing = _make_agent_public()  # wellKnownURI = https://example.com/.well-known/agent.json
+    updated_card = {**MOCK_AGENT_CARD, "name": "Moved Agent"}
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.validate_well_known_uri", return_value=[]), \
+         patch("app.main.fetch_agent_card", return_value=(updated_card, None)) as mock_fetch, \
+         patch("app.main._agent_create_from_card") as mock_build:
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        instance.get_by_well_known_uri = AsyncMock(return_value=None)
+        instance.get_by_host = AsyncMock(return_value=None)
+        instance.update = AsyncMock(return_value=_make_agent_in_db())
+        mock_build.return_value = _make_agent_in_db()
+
+        response = client.put(f"/agents/{MOCK_UUID}", json={"wellKnownURI": NEW_URI})
+
+    assert response.status_code == 200
+    # The NEW url was fetched — not the stale existing one.
+    mock_fetch.assert_called_once_with(NEW_URI)
+    # And the new url is what gets persisted (passed to the card->row builder).
+    assert mock_build.call_args[0][1] == NEW_URI
+
+
+def test_update_agent_no_body_refetches_existing(client):
+    """PUT with no body re-fetches the existing wellKnownURI (backward compatible)."""
+    existing = _make_agent_public()
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)) as mock_fetch:
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        instance.update = AsyncMock(return_value=_make_agent_in_db())
+
+        response = client.put(f"/agents/{MOCK_UUID}")
+
+    assert response.status_code == 200
+    mock_fetch.assert_called_once_with(str(existing.wellKnownURI))
+
+
+def test_update_agent_body_uri_conflict(client):
+    """PUT to a wellKnownURI owned by a different agent returns 409."""
+    existing = _make_agent_public()
+    other = _make_agent_in_db(id=UUID(OTHER_UUID), name="Other Agent")
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.validate_well_known_uri", return_value=[]):
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        instance.get_by_well_known_uri = AsyncMock(return_value=other)
+
+        response = client.put(f"/agents/{MOCK_UUID}", json={"wellKnownURI": NEW_URI})
+
+    assert response.status_code == 409
+    assert OTHER_UUID in response.json()["detail"]
+
+
+async def test_repo_update_persists_well_known_uri():
+    """Repo-level regression for #133: AgentRepository.update() must write the
+    well_known_uri column, else a body-supplied URI is fetched but never
+    persisted and the worker keeps health-checking the dead URL.
+
+    Endpoint mock tests can't catch this (they stop at _agent_create_from_card),
+    so this drives the real UPDATE through a fake db and asserts the SQL sets
+    well_known_uri and binds the new URI.
+    """
+    from app.repositories import AgentRepository
+
+    captured = {}
+
+    async def fake_fetchrow(query, *params):
+        captured["query"] = query
+        captured["params"] = params
+        return MOCK_AGENT_ROW
+
+    db = AsyncMock()
+    db.fetchrow = fake_fetchrow
+
+    agent = _make_agent_in_db(wellKnownURI=NEW_URI)
+    await AgentRepository(db).update(UUID(MOCK_UUID), agent)
+
+    sql = " ".join(captured["query"].split()).lower()
+    assert "well_known_uri = $1" in sql
+    # well_known_uri is $1, so the new URI must be the first bound param.
+    # (HttpUrl may normalize, so compare on prefix.)
+    assert str(captured["params"][0]).startswith(NEW_URI), (
+        f"new wellKnownURI not bound to well_known_uri = $1; params={captured['params']}"
+    )
+
+
 # ============================================================================
 # Delete Agent (DELETE /agents/{id})
 # ============================================================================

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -501,6 +501,57 @@ def test_get_agent_health_not_found(client):
     assert response.status_code == 404
 
 
+async def test_get_health_status_does_not_project_bound_param():
+    """Regression for #134: GET /agents/{id}/health 500'd with asyncpg
+    'inconsistent types deduced for parameter $1: uuid versus text'.
+
+    The query bound the agent_id placeholder ($1) twice: once as a bare
+    projected value (`SELECT $1 as agent_id`, inferred text) and once in
+    `WHERE agent_id = $1` (inferred uuid). asyncpg cannot reconcile the two,
+    so the endpoint 500'd for every agent with health rows. The fix drops the
+    bare projection and returns the Python agent_id instead.
+
+    No live Postgres in CI, so we can't trigger asyncpg's deducer directly.
+    Instead we assert the structural cause is gone: the SQL must not project a
+    bare placeholder, and the returned agent_id must come from the argument.
+    """
+    from uuid import uuid4
+
+    from app.repositories import HealthCheckRepository
+
+    captured = {}
+
+    async def fake_fetchrow(query, *params):
+        captured["query"] = query
+        captured["params"] = params
+        return {
+            "is_healthy": True,
+            "uptime_percentage": 100.0,
+            "avg_response_time_ms": 42,
+            "last_check": datetime.fromisoformat("2024-01-01T00:00:00"),
+            "total_checks": 3,
+            "successful_checks": 3,
+        }
+
+    db = AsyncMock()
+    db.fetchrow = fake_fetchrow
+    agent_id = uuid4()
+
+    status = await HealthCheckRepository(db).get_health_status(agent_id)
+
+    sql = " ".join(captured["query"].split())
+    # The bare projection that caused the uuid-vs-text conflict must be gone.
+    # An explicit cast (e.g. `$1::uuid as agent_id`) would also be acceptable,
+    # so we only forbid the un-cast projection.
+    assert "$1 as agent_id" not in sql.lower()
+    # $1 is still bound exactly once, in the WHERE clause.
+    assert sql.count("$1") == 1
+    assert "where agent_id = $1" in sql.lower()
+    # agent_id comes from the Python argument, not a projected row column.
+    assert status is not None
+    assert status.agent_id == agent_id
+
+
 def test_get_agent_uptime_not_found(client):
     """GET uptime for agent with no data returns 404."""
     with patch("app.main.HealthCheckRepository") as mock_repo:

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -778,3 +778,85 @@ def test_api_root(client):
     assert response.status_code == 200
     body = response.json()
     assert body["name"] == "A2A Registry API"
+
+
+# ============================================================================
+# Chat proxy (#135): must target the card's url, not the wellKnownURI host
+# ============================================================================
+#
+# An agent can publish its card on one host (wellKnownURI) and run the actual
+# A2A handler on another (card.url) — a common split-host deployment. The chat
+# proxy used to derive the A2A base URL from the wellKnownURI host, so JSON-RPC
+# POSTs went to the wrong host and 502'd. The fix builds the client from the
+# parsed card (factory.create), whose transport targets card.url.
+
+
+def test_chat_targets_card_url_not_well_known_host(client):
+    """The SDK client must be built from the parsed card, so the message is
+    sent to the card's declared url, not the wellKnownURI host."""
+    from unittest.mock import MagicMock
+
+    # Card published on cesaryague.es but A2A handler lives on workers.dev.
+    split_host_card = {
+        **MOCK_AGENT_CARD,
+        "url": "https://paki-api.elfresonero.workers.dev/a2a",
+    }
+    existing = _make_agent_public(
+        wellKnownURI="https://cesaryague.es/.well-known/agent.json",
+        url="https://paki-api.elfresonero.workers.dev/a2a",
+    )
+
+    async def _events():
+        ev = MagicMock()
+        ev.HasField = lambda f: f == "message"
+        ev.message = MagicMock()
+        yield ev
+
+    fake_client = MagicMock()
+    fake_client.send_message = MagicMock(return_value=_events())
+
+    captured = {}
+
+    def fake_create(card):
+        captured["card"] = card
+        return fake_client
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.fetch_agent_card", return_value=(split_host_card, None)) as mock_fetch, \
+         patch("app.main._extract_text", return_value="hi from worker"), \
+         patch("app.main.ClientFactory") as mock_factory_cls:
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        mock_factory_cls.return_value.create = fake_create
+
+        response = client.post(f"/agents/{MOCK_UUID}/chat", json={"message": "hi"})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["response"] == "hi from worker"
+    # The card was refetched from the agent's stored wellKnownURI, not request input.
+    mock_fetch.assert_called_once_with("https://cesaryague.es/.well-known/agent.json")
+    # The client was built from the parsed card whose endpoint is the worker.
+    parsed_card = captured["card"]
+    iface = (getattr(parsed_card, "supported_interfaces", None)
+             or getattr(parsed_card, "supportedInterfaces", None))
+    assert iface, "parsed card has no supported interface url"
+    assert iface[0].url == "https://paki-api.elfresonero.workers.dev/a2a"
+
+
+def test_parsed_split_host_card_resolves_transport_to_card_url():
+    """SDK contract: parse_agent_card + ClientFactory.create build a transport
+    whose URL is the card's url, even when that differs from the discovery host.
+    Pins the SDK behavior the #135 fix relies on."""
+    import httpx
+    from a2a.client import ClientConfig, ClientFactory
+    from a2a.client.card_resolver import parse_agent_card
+
+    card = parse_agent_card({
+        **MOCK_AGENT_CARD,
+        "url": "https://paki-api.elfresonero.workers.dev/a2a",
+    })
+    hc = httpx.AsyncClient()
+    sdk_client = ClientFactory(ClientConfig(httpx_client=hc, streaming=False)).create(card)
+    transport = getattr(sdk_client, "_transport", None) or getattr(sdk_client, "transport", None)
+    assert transport is not None
+    assert transport.url == "https://paki-api.elfresonero.workers.dev/a2a"

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -892,6 +892,44 @@ def test_chat_rejects_private_card_url_after_refetch(client):
     fake_client.send_message.assert_not_called()
 
 
+def test_chat_fails_closed_when_target_url_indeterminate(client):
+    """If the SDK client's transport url can't be read, the SSRF guard must
+    fail closed (reject) rather than send blind — so a future SDK that hides
+    the transport target can't silently bypass the guard."""
+    from unittest.mock import MagicMock
+
+    existing = _make_agent_public(
+        wellKnownURI="https://public-host.example/.well-known/agent.json",
+        url="https://public-host.example/a2a",
+    )
+
+    fake_client = MagicMock()
+    fake_client.send_message = MagicMock(side_effect=AssertionError("send_message must not be called"))
+
+    def fake_create(card):
+        c = MagicMock()
+        # No resolvable transport url: _transport / transport both absent.
+        c._transport = None
+        c.transport = None
+        c.send_message = fake_client.send_message
+        return c
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.HealthCheckRepository") as mock_health_cls, \
+         patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)), \
+         patch("app.main.ClientFactory") as mock_factory_cls:
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        mock_health_cls.return_value.create = AsyncMock(return_value=None)
+        mock_factory_cls.return_value.create = fake_create
+
+        response = client.post(f"/agents/{MOCK_UUID}/chat", json={"message": "hi"})
+
+    assert response.status_code == 400, response.text
+    assert "not publicly reachable" in response.json()["detail"]
+    fake_client.send_message.assert_not_called()
+
+
 def test_parsed_split_host_card_resolves_transport_to_card_url():
     """SDK contract: parse_agent_card + ClientFactory.create build a transport
     whose URL is the card's url, even when that differs from the discovery host.
@@ -900,9 +938,19 @@ def test_parsed_split_host_card_resolves_transport_to_card_url():
     from a2a.client import ClientConfig, ClientFactory
     from a2a.client.card_resolver import parse_agent_card
 
+    # Self-contained card dict — parse_agent_card mutates its input in place
+    # (it moves `url` into supported_interfaces), so don't derive from a shared
+    # module-level fixture or this becomes order-dependent.
     card = parse_agent_card({
-        **MOCK_AGENT_CARD,
+        "protocolVersion": "0.3.0",
+        "name": "Split Host Agent",
+        "description": "d",
         "url": "https://paki-api.elfresonero.workers.dev/a2a",
+        "version": "1.0.0",
+        "capabilities": {},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
     })
     hc = httpx.AsyncClient()
     sdk_client = ClientFactory(ClientConfig(httpx_client=hc, streaming=False)).create(card)


### PR DESCRIPTION
Fixes #134, #133, and #135. Three small, independent backend bugs found while triaging open issues. Each fix is a separate commit with a fail-on-old / pass-on-new regression test (mirroring #132).

## #134 — `GET /agents/{id}/health` 500s with "uuid versus text"
`get_health_status` bound `$1` twice: as a bare projected value (`SELECT $1 as agent_id`, inferred `text`) and in `WHERE agent_id = $1` (inferred `uuid`). asyncpg can't reconcile them, so the endpoint 500'd for any agent with health rows. Fix: drop the gratuitous `SELECT $1` and return the Python `agent_id` argument.

## #133 — `PUT /agents/{id}` ignored the request body
Always re-fetched the existing `wellKnownURI` and never parsed the body, so an agent stuck on a dead URL could never be repointed. Fix: parse an optional body `wellKnownURI` (no body unchanged, backward compatible); validate + dup-check by URI and host (excluding self); and persist it. `AgentRepository.update()` previously didn't write `well_known_uri`; the UPDATE now sets `well_known_uri = $1`.

## #135 — chat proxy 502s for split-host agents
Derived the A2A base URL from the `wellKnownURI` host, so agents that publish their card on one domain but run the handler on another got JSON-RPC POSTs to the wrong host. Fix: refetch the card from the stored wellKnownURI, then `factory.create(parse_agent_card(card))`, whose transport targets the card's declared `url`. Also re-raise `HTTPException` inside the proxy so a card-load failure keeps its real status.

## Tests
Repo/SQL-level + endpoint tests for each. Full suite 121 passed. All new behaviors verified fail-on-old / pass-on-new.

## Note
Merging to `main` auto-triggers the production deploy (`deploy-backend.yml` on push to main for `backend/**`). Holding merge for the deploy gate. Reviewed in tandem with the codex reviewer (a2a-registry-2).
