### PR TITLE
chore: ignore screenshot debris, fix ruff config, hoist stranded import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ website/dist/
 # MCP stuff
 .playwright-mcp/
 .claude/scheduled_tasks.lock
+
+# Ad-hoc screenshot debris dropped in the website/ root by UI/browser tooling.
+# Real website images live under website/public/ and website/src/, so this only
+# catches stray captures at the top level (agentdance-*.png, *-preview.png, etc).
+/website/*.png

--- a/backend/app/validators.py
+++ b/backend/app/validators.py
@@ -7,11 +7,11 @@ used as the primary validator, keeping us in sync with spec updates automaticall
 Falls back to manual validation if the SDK is not available.
 """
 
+from typing import Any
+
 # a2a-sdk 1.0 uses protobuf types instead of pydantic, so AgentCard.model_validate()
 # is no longer available. We use manual validation exclusively.
 _SDK_AVAILABLE = False
-
-from typing import Any
 
 
 def validate_agent_card(card_data: dict[str, Any], strict: bool = False) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ target-version = ["py310", "py311", "py312"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Routine hygiene, separate from the bug fixes. No behavior change.

- **`.gitignore`**: ignore `/website/*.png` — ad-hoc UI/browser-tool screenshots (agentdance-*, *-preview, debug-ui, inspector captures) had been piling up untracked in the website root. Real website images live under `website/public/` and `website/src/`, so the rule is scoped to the top level only. Also removed the 16 stray files locally (they were never tracked).
- **`pyproject.toml`**: move ruff `select` under `[tool.ruff.lint]`. The top-level form is deprecated and emitted a warning on every ruff run. (`backend/pyproject.toml` was already on the new form.)
- **`backend/app/validators.py`**: hoist `from typing import Any` to the top of the file. It sat below `_SDK_AVAILABLE = False`, which looked like an SDK-availability guard but isn't — the constant doesn't gate the import, and leaving the import stranded required suppressing both `E402` (import-not-at-top) and `I001` (unsorted-imports). Moving it up satisfies both linters with no functional change.

Tests: backend suite green (134 passed). Ruff clean on `backend/app/`.

Note: `backend/app/validators.py` is under `backend/**`, so merging triggers the production deploy pipeline. Approved by Prasanna to ship as its own deploy.