### PR TITLE
chore(scripts): fix ruff lint findings

### DIFF
--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -15,11 +15,11 @@ import json
 import sys
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 import aiohttp
 
-from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
 
 from app.smoke_test import TASK_PROBE_USER_AGENT, smoke_test
@@ -73,7 +73,12 @@ async def fetch_all_agents(session: aiohttp.ClientSession) -> list[dict]:
     return agents
 
 
-async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool, probe_tasks: bool = False) -> Result:
+async def check_one(
+    agent: dict,
+    session: aiohttp.ClientSession,
+    strict: bool,
+    probe_tasks: bool = False,
+) -> Result:
     result = Result(
         name=agent["name"],
         well_known_uri=agent.get("wellKnownURI", ""),
@@ -90,7 +95,10 @@ async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool, p
         async with session.get(
             result.well_known_uri,
             timeout=aiohttp.ClientTimeout(total=TIMEOUT),
-            headers={"User-Agent": "A2A-Registry-ConformanceCheck/1.0", "Accept": "application/json"},
+            headers={
+                "User-Agent": "A2A-Registry-ConformanceCheck/1.0",
+                "Accept": "application/json",
+            },
             allow_redirects=True,
             ssl=False,
         ) as resp:
@@ -123,7 +131,9 @@ async def check_one(agent: dict, session: aiohttp.ClientSession, strict: bool, p
             except Exception as e:
                 result.task_category = "OTHER"
                 result.task_response_ms = None
-                result.fetch_error = (result.fetch_error or "") + f" task-probe error: {str(e)[:80]}"
+                result.fetch_error = (
+                    (result.fetch_error or "") + f" task-probe error: {str(e)[:80]}"
+                )
 
     except asyncio.TimeoutError:
         result.fetch_error = f"Timeout (>{TIMEOUT}s)"
@@ -182,7 +192,7 @@ async def main(strict: bool, as_json: bool, probe_tasks: bool):
 
     # ── Human-readable output ─────────────────────────────────────────────────
 
-    W = 42  # name column width
+    name_w = 42  # name column width
 
     print(f"{'='*80}")
     print(f"  A2A CONFORMANCE SCAN  (strict={strict})")
@@ -192,13 +202,13 @@ async def main(strict: bool, as_json: bool, probe_tasks: bool):
     print(f"{'─'*60}")
     for r in sorted(conformant, key=lambda x: x.name):
         flag = " [was non-standard]" if r.current_conformance is False else ""
-        print(f"  {r.name:<{W}}  {r.response_ms:>4}ms{flag}")
+        print(f"  {r.name:<{name_w}}  {r.response_ms:>4}ms{flag}")
 
     print(f"\n❌  NON-CONFORMANT ({len(non_conformant)})")
     print(f"{'─'*60}")
     for r in sorted(non_conformant, key=lambda x: x.name):
         flag = " [was standard]" if r.current_conformance is True else ""
-        print(f"  {r.name:<{W}}{flag}")
+        print(f"  {r.name:<{name_w}}{flag}")
         for e in r.errors[:3]:
             print(f"      • {e}")
         if len(r.errors) > 3:
@@ -207,12 +217,18 @@ async def main(strict: bool, as_json: bool, probe_tasks: bool):
     print(f"\n⚠️   UNREACHABLE ({len(unreachable)})")
     print(f"{'─'*60}")
     for r in sorted(unreachable, key=lambda x: x.name):
-        print(f"  {r.name:<{W}}  {r.fetch_error}")
+        print(f"  {r.name:<{name_w}}  {r.fetch_error}")
 
     print(f"\n{'='*80}")
-    print(f"  SUMMARY: {len(conformant)} conformant / {len(non_conformant)} non-conformant / {len(unreachable)} unreachable  (total {len(results)})")
+    print(
+        f"  SUMMARY: {len(conformant)} conformant / {len(non_conformant)} non-conformant"
+        f" / {len(unreachable)} unreachable  (total {len(results)})"
+    )
 
-    changed = [r for r in results if r.conformant is not None and r.conformant != r.current_conformance]
+    changed = [
+        r for r in results
+        if r.conformant is not None and r.conformant != r.current_conformance
+    ]
     if changed:
         print(f"\n  🔄  CHANGED since last check ({len(changed)}):")
         for r in changed:
@@ -223,7 +239,10 @@ async def main(strict: bool, as_json: bool, probe_tasks: bool):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--strict", action="store_true", help="Full A2A spec validation (requires all fields)")
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Full A2A spec validation (requires all fields)",
+    )
     parser.add_argument("--json", dest="as_json", action="store_true", help="JSON output")
     parser.add_argument("--probe-tasks", dest="probe_tasks", action="store_true",
                         help="Also send A2A message/send to each agent (matches worker behavior)")

--- a/scripts/export_agents.py
+++ b/scripts/export_agents.py
@@ -20,7 +20,10 @@ import sys
 try:
     import aiohttp
 except ImportError:
-    print("Error: aiohttp not installed. Run from backend directory with: cd backend && uv run python ../scripts/export_agents.py")
+    print(
+        "Error: aiohttp not installed. Run from backend directory with: "
+        "cd backend && uv run python ../scripts/export_agents.py"
+    )
     sys.exit(1)
 
 DEFAULT_API_URL = "http://localhost:17001"

--- a/scripts/seed_agents.py
+++ b/scripts/seed_agents.py
@@ -13,7 +13,8 @@ Usage:
     cat agents.txt | cd backend && uv run python ../scripts/seed_agents.py --stdin
 
     # Export from production, seed locally
-    cd backend && uv run python ../scripts/export_agents.py --api https://beta.a2aregistry.org/api | uv run python ../scripts/seed_agents.py --stdin
+    cd backend && uv run python ../scripts/export_agents.py \
+        --api https://beta.a2aregistry.org/api | uv run python ../scripts/seed_agents.py --stdin
 """
 
 import argparse
@@ -24,13 +25,18 @@ from pathlib import Path
 try:
     import aiohttp
 except ImportError:
-    print("Error: aiohttp not installed. Run from backend directory with: cd backend && uv run python ../scripts/seed_agents.py")
+    print(
+        "Error: aiohttp not installed. Run from backend directory with: "
+        "cd backend && uv run python ../scripts/seed_agents.py"
+    )
     sys.exit(1)
 
 DEFAULT_API_URL = "http://localhost:17001"
 
 
-async def register_agent(session: aiohttp.ClientSession, api_url: str, well_known_uri: str) -> tuple[bool, str]:
+async def register_agent(
+    session: aiohttp.ClientSession, api_url: str, well_known_uri: str,
+) -> tuple[bool, str]:
     """Register a single agent via the API."""
     try:
         async with session.post(


### PR DESCRIPTION
Quick-win lint cleanup, no behavior change. Clears the 12 ruff findings in `scripts/`:

- **I001** — import block sorted (auto-fix).
- **E501** (10×) — wrapped long lines: function signatures, a headers dict, an argparse `add_argument`, error-message prints (split string literals — output unchanged), a summary print, and a list comprehension. The `seed_agents.py` docstring command example uses a shell `\` continuation so it stays copy-pasteable.
- **N806** — renamed the `W` column-width local to `name_w`.

`scripts/` is outside the deploy trigger paths (`backend/`/`website/`/`helm/`/`hello-world-agent/`), so this does **not** trigger a production deploy.

Verified: `ruff check scripts/` clean; all three files parse.