### PR TITLE
fix(security): guard agent-card fetches against SSRF

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,8 +1,13 @@
 """Utility functions for agent validation and tracking"""
 
+import asyncio
+import ipaddress
+import socket
 from typing import Any, Optional, Tuple
+from urllib.parse import urljoin, urlparse
 
 import aiohttp
+from aiohttp.abc import AbstractResolver
 
 from .config import settings
 from .models import AgentCreate
@@ -20,6 +25,165 @@ except Exception:
     posthog_client = None
 
 
+_BLOCKED_HOSTS = frozenset({
+    "localhost",
+    "metadata.google.internal",
+    "metadata.google",
+    "kubernetes.default.svc",
+})
+
+_BLOCKED_SUFFIXES = (".internal", ".local", ".svc", ".cluster.local")
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+_MAX_AGENT_CARD_REDIRECTS = 3
+
+
+def _is_private_address(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    if ip.version == 6 and ip.ipv4_mapped:
+        ip = ip.ipv4_mapped
+    if ip.version == 4 and ip in _CGNAT_NETWORK:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _is_blocked_hostname(hostname: str) -> bool:
+    host = hostname.rstrip(".").lower()
+    return host in _BLOCKED_HOSTS or any(host.endswith(suffix) for suffix in _BLOCKED_SUFFIXES)
+
+
+class _PinnedResolver(AbstractResolver):
+    """aiohttp resolver that reuses the addresses already passed by the SSRF guard."""
+
+    def __init__(self, hostname: str, records: list[dict[str, Any]]):
+        self.hostname = hostname.rstrip(".").lower()
+        self.records = records
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: socket.AddressFamily = socket.AF_INET,
+    ) -> list[dict[str, Any]]:
+        if host.rstrip(".").lower() != self.hostname:
+            raise OSError(f"Unexpected host during guarded fetch: {host}")
+        if family not in (socket.AF_UNSPEC, 0):
+            filtered = [record for record in self.records if record["family"] == family]
+            if filtered:
+                return filtered
+        return self.records
+
+    async def close(self) -> None:
+        pass
+
+
+async def _resolve_public_addresses(hostname: str, port: int) -> list[dict[str, Any]]:
+    if _is_blocked_hostname(hostname):
+        raise ValueError(f"Host '{hostname}' is not publicly reachable")
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(
+            hostname,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror as exc:
+        raise ValueError(f"Could not resolve host '{hostname}'") from exc
+
+    records: list[dict[str, Any]] = []
+    seen: set[tuple[int, str, int]] = set()
+    for family, _, proto, _, address in infos:
+        if family == socket.AF_INET6:
+            resolved_host, resolved_port = address[:2]
+        elif family == socket.AF_INET:
+            resolved_host, resolved_port = address
+        else:
+            continue
+
+        if _is_private_address(resolved_host):
+            raise ValueError(f"Host '{hostname}' resolves to a non-public address")
+
+        key = (family, resolved_host, resolved_port)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append(
+            {
+                "hostname": hostname,
+                "host": resolved_host,
+                "port": resolved_port,
+                "family": family,
+                "proto": proto,
+                "flags": socket.AI_NUMERICHOST,
+            }
+        )
+
+    if not records:
+        raise ValueError(f"Could not resolve host '{hostname}'")
+    return records
+
+
+async def _guarded_connector_for_url(url: str) -> aiohttp.TCPConnector:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Agent card URL must use http or https")
+    if not parsed.hostname:
+        raise ValueError("Agent card URL must include a hostname")
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    records = await _resolve_public_addresses(parsed.hostname, port)
+    return aiohttp.TCPConnector(
+        resolver=_PinnedResolver(parsed.hostname, records),
+        family=socket.AF_UNSPEC,
+    )
+
+
+def _redirect_url(current_url: str, location: str | None) -> str:
+    if not location:
+        raise ValueError("Redirect response missing Location header")
+    next_url = urljoin(current_url, location)
+    parsed = urlparse(next_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Redirect target must use http or https")
+    return next_url
+
+
+async def _get_guarded_json(url: str, *, user_agent: str) -> Tuple[Optional[dict[str, Any]], Optional[str]]:
+    current_url = url
+    for _redirect_count in range(_MAX_AGENT_CARD_REDIRECTS + 1):
+        connector = await _guarded_connector_for_url(current_url)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            async with session.get(
+                current_url,
+                timeout=aiohttp.ClientTimeout(total=settings.health_check_timeout_seconds),
+                headers={
+                    "User-Agent": user_agent,
+                    "Accept": "application/json",
+                },
+                allow_redirects=False,
+            ) as response:
+                if 300 <= response.status < 400:
+                    current_url = _redirect_url(current_url, response.headers.get("Location"))
+                    continue
+                if response.status != 200:
+                    return None, f"Agent card endpoint returned HTTP {response.status}"
+
+                try:
+                    return await response.json(), None
+                except Exception as e:
+                    return None, f"Invalid JSON in agent card: {e}"
+
+    return None, "Too many redirects while fetching agent card"
+
+
 async def verify_well_known_uri(agent_data: AgentCreate) -> Tuple[bool, str]:
     """
     Verify agent ownership by fetching wellKnownURI and comparing key fields.
@@ -33,44 +197,35 @@ async def verify_well_known_uri(agent_data: AgentCreate) -> Tuple[bool, str]:
     well_known_uri = str(agent_data.wellKnownURI)
 
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                well_known_uri,
-                timeout=aiohttp.ClientTimeout(total=settings.health_check_timeout_seconds),
-                headers={
-                    "User-Agent": "A2A-Registry-Backend/1.0",
-                    "Accept": "application/json",
-                },
-            ) as response:
-                if response.status != 200:
-                    return (
-                        False,
-                        f"Well-known endpoint returned HTTP {response.status}",
-                    )
+        remote_agent, error = await _get_guarded_json(
+            well_known_uri,
+            user_agent="A2A-Registry-Backend/1.0",
+        )
+        if error:
+            return False, error
+        if remote_agent is None:
+            return False, "Internal error: well-known fetch returned no data"
 
-                try:
-                    remote_agent = await response.json()
-                except Exception as e:
-                    return False, f"Invalid JSON in well-known endpoint: {e}"
+        # Compare key fields
+        mismatches = []
+        for field in ["name", "description"]:
+            local_val = getattr(agent_data, field)
+            remote_val = remote_agent.get(field)
+            if local_val != remote_val:
+                mismatches.append(
+                    f"{field}: local='{local_val}' vs remote='{remote_val}'"
+                )
 
-                # Compare key fields
-                mismatches = []
-                for field in ["name", "description"]:
-                    local_val = getattr(agent_data, field)
-                    remote_val = remote_agent.get(field)
-                    if local_val != remote_val:
-                        mismatches.append(
-                            f"{field}: local='{local_val}' vs remote='{remote_val}'"
-                        )
+        if mismatches:
+            return (
+                False,
+                "Field mismatches found:\n  " + "\n  ".join(mismatches),
+            )
 
-                if mismatches:
-                    return (
-                        False,
-                        "Field mismatches found:\n  " + "\n  ".join(mismatches),
-                    )
+        return True, "Ownership verified successfully"
 
-                return True, "Ownership verified successfully"
-
+    except ValueError as e:
+        return False, str(e)
     except aiohttp.ClientError as e:
         return False, f"Network error accessing {well_known_uri}: {e}"
     except Exception as e:
@@ -88,30 +243,24 @@ async def fetch_agent_card(well_known_uri: str) -> Tuple[Optional[dict[str, Any]
         Tuple of (agent_card_dict or None, error_message or None)
     """
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                well_known_uri,
-                timeout=aiohttp.ClientTimeout(total=settings.health_check_timeout_seconds),
-                headers={
-                    "User-Agent": "A2A-Registry/1.0",
-                    "Accept": "application/json",
-                },
-            ) as response:
-                if response.status != 200:
-                    return None, f"Agent card endpoint returned HTTP {response.status}"
+        agent_card, error = await _get_guarded_json(
+            well_known_uri,
+            user_agent="A2A-Registry/1.0",
+        )
+        if error:
+            return None, error
+        if agent_card is None:
+            return None, "Internal error: agent card fetch returned no data"
 
-                try:
-                    agent_card = await response.json()
-                except Exception as e:
-                    return None, f"Invalid JSON in agent card: {e}"
+        normalised = _normalise_fields(agent_card)
+        validation_errors = validate_agent_card(normalised)
+        if validation_errors:
+            return None, "Agent card validation failed: " + "; ".join(validation_errors)
 
-                normalised = _normalise_fields(agent_card)
-                validation_errors = validate_agent_card(normalised)
-                if validation_errors:
-                    return None, "Agent card validation failed: " + "; ".join(validation_errors)
+        return normalised, None
 
-                return normalised, None
-
+    except ValueError as e:
+        return None, str(e)
     except aiohttp.ClientError as e:
         return None, f"Network error fetching agent card: {e}"
     except Exception as e:

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -162,6 +162,23 @@ def test_register_agent_fetch_fails(client):
     assert "Connection refused" in response.json()["detail"]
 
 
+def test_register_agent_rejects_private_well_known_uri(client):
+    """POST /agents/register is covered by the centralized card-fetch SSRF guard."""
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.validate_well_known_uri", return_value=[]):
+        instance = mock_repo.return_value
+        instance.get_by_well_known_uri = AsyncMock(return_value=None)
+        instance.get_by_host = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/agents/register",
+            json={"wellKnownURI": "http://127.0.0.1/.well-known/agent.json"},
+        )
+
+    assert response.status_code == 400
+    assert "non-public" in response.json()["detail"]
+
+
 def test_register_agent_host_duplicate(client):
     """Reject registration when another agent from the same host exists."""
     existing = _make_agent_in_db()
@@ -268,6 +285,26 @@ def test_update_agent_fetch_fails(client):
 
     assert response.status_code == 400
     assert "Timeout" in response.json()["detail"]
+
+
+def test_update_agent_rejects_private_body_well_known_uri(client):
+    """PUT /agents/{id} is covered by the centralized card-fetch SSRF guard."""
+    existing = _make_agent_public()
+
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.validate_well_known_uri", return_value=[]):
+        instance = mock_repo.return_value
+        instance.get_by_id = AsyncMock(return_value=existing)
+        instance.get_by_well_known_uri = AsyncMock(return_value=None)
+        instance.get_by_host = AsyncMock(return_value=None)
+
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            json={"wellKnownURI": "http://127.0.0.1/.well-known/agent.json"},
+        )
+
+    assert response.status_code == 400
+    assert "non-public" in response.json()["detail"]
 
 
 # --- #133: PUT must honor a wellKnownURI in the request body ----------------

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,204 @@
+"""Tests for utility functions that perform outbound network fetches."""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from app import utils
+
+from .conftest import MOCK_AGENT_CARD
+
+
+async def test_fetch_agent_card_rejects_loopback_before_http():
+    """Direct private IPs must be rejected before creating an HTTP session."""
+    with patch("app.utils.aiohttp.ClientSession", side_effect=AssertionError("no HTTP")):
+        card, error = await utils.fetch_agent_card("http://127.0.0.1/.well-known/agent.json")
+
+    assert card is None
+    assert "non-public" in error
+
+
+async def test_fetch_agent_card_rejects_if_any_resolved_address_is_private(monkeypatch):
+    """A hostname is unsafe if any DNS answer is private, not just the first."""
+    calls = []
+
+    async def fake_getaddrinfo(host, port, family=0, type=0):
+        calls.append((host, port, family, type))
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", port)),
+        ]
+
+    loop = utils.asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+    with patch("app.utils.aiohttp.ClientSession", side_effect=AssertionError("no HTTP")):
+        card, error = await utils.fetch_agent_card(
+            "https://mixed.example/.well-known/agent.json"
+        )
+
+    assert card is None
+    assert "non-public" in error
+    assert calls
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://[::1]/.well-known/agent.json",
+        "http://[::ffff:127.0.0.1]/.well-known/agent.json",
+        "http://169.254.169.254/latest/meta-data",
+        "http://100.64.0.1/.well-known/agent.json",
+        "http://metadata.google.internal/.well-known/agent.json",
+        "http://kubernetes.default.svc/.well-known/agent.json",
+    ],
+)
+async def test_fetch_agent_card_rejects_internal_url_forms(url):
+    with patch("app.utils.aiohttp.ClientSession", side_effect=AssertionError("no HTTP")):
+        card, error = await utils.fetch_agent_card(url)
+
+    assert card is None
+    assert error
+
+
+async def test_fetch_agent_card_follows_public_redirect_with_each_hop_guarded(monkeypatch):
+    """Public canonical redirects are allowed, but aiohttp auto-follow stays disabled."""
+    connector = object()
+    guarded_urls = []
+    get_calls = []
+
+    async def fake_guarded_connector(url):
+        guarded_urls.append(url)
+        return connector
+
+    class FakeResponse:
+        def __init__(self, status, headers=None, payload=None):
+            self.status = status
+            self.headers = headers or {}
+            self.payload = payload or MOCK_AGENT_CARD
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self):
+            return self.payload
+
+    class FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            get_calls.append((url, kwargs))
+            if len(get_calls) == 1:
+                return FakeResponse(301, headers={"Location": "/.well-known/agent-card.json"})
+            return FakeResponse(200)
+
+    monkeypatch.setattr(utils, "_guarded_connector_for_url", fake_guarded_connector)
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", FakeSession)
+
+    card, error = await utils.fetch_agent_card("https://example.com/.well-known/agent.json")
+
+    assert error is None
+    assert card["name"] == MOCK_AGENT_CARD["name"]
+    assert guarded_urls == [
+        "https://example.com/.well-known/agent.json",
+        "https://example.com/.well-known/agent-card.json",
+    ]
+    assert [call[0] for call in get_calls] == guarded_urls
+    assert all(call[1]["allow_redirects"] is False for call in get_calls)
+
+
+async def test_fetch_agent_card_rejects_private_redirect_target(monkeypatch):
+    """A redirect hop is rejected if its target fails the same SSRF guard."""
+    guarded_urls = []
+
+    async def fake_guarded_connector(url):
+        guarded_urls.append(url)
+        if url.startswith("http://127.0.0.1"):
+            raise ValueError("Host '127.0.0.1' resolves to a non-public address")
+        return object()
+
+    class FakeResponse:
+        status = 302
+        headers = {"Location": "http://127.0.0.1/.well-known/agent.json"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(utils, "_guarded_connector_for_url", fake_guarded_connector)
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", FakeSession)
+
+    card, error = await utils.fetch_agent_card("https://example.com/.well-known/agent.json")
+
+    assert card is None
+    assert "non-public" in error
+    assert guarded_urls == [
+        "https://example.com/.well-known/agent.json",
+        "http://127.0.0.1/.well-known/agent.json",
+    ]
+
+
+async def test_fetch_agent_card_accepts_public_non_redirect(monkeypatch):
+    connector = object()
+
+    async def fake_guarded_connector(_url):
+        return connector
+
+    class FakeResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self):
+            return MOCK_AGENT_CARD
+
+    class FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(utils, "_guarded_connector_for_url", fake_guarded_connector)
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", FakeSession)
+
+    card, error = await utils.fetch_agent_card("https://example.com/.well-known/agent.json")
+
+    assert error is None
+    assert card["name"] == MOCK_AGENT_CARD["name"]


### PR DESCRIPTION
## Summary
- add a centralized guarded connector for agent-card fetches
- resolve every host address and reject non-public/internal results, including loopback, RFC1918, CGNAT `100.64.0.0/10`, link-local/cloud metadata, reserved, multicast, unspecified, IPv4-mapped IPv6, and blocked internal hostnames
- pin aiohttp to the already-vetted DNS answers to avoid a second unchecked resolution
- replace aiohttp auto-redirects with a bounded manual redirect loop; every hop is re-validated through the same guard before following
- covers `POST /agents/register`, `PUT /agents/{id}`, chat-time card refetch, and full-payload ownership verification through shared utility code

## Tests
- PASS: `uv run --extra dev pytest tests/test_utils.py tests/test_endpoints.py::test_register_agent_rejects_private_well_known_uri tests/test_endpoints.py::test_update_agent_rejects_private_body_well_known_uri -q` (13 passed)
- PASS: `uv run --extra dev ruff check app/utils.py tests/test_utils.py tests/test_endpoints.py`
- PASS: `uv run --extra dev pytest -q` (147 passed)

## Fail-on-old check
Keeping the new tests but restoring old `backend/app/utils.py` makes the key regressions fail: loopback reaches `ClientSession` instead of rejecting, DNS private-answer guard is absent, and redirect-control helper is absent.

## Security behavior change
Agent card URLs that resolve to internal/private/link-local/reserved addresses are rejected before fetch. Redirects are allowed only through a bounded manual loop where each target URL is validated before the next hop.
