### PR TITLE
chore: remove broken pre-commit hooks (dead validate-agents, always-fail ty)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,16 +18,10 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # Type checking with ty
-  - repo: local
-    hooks:
-      - id: ty-check
-        name: Type check with ty
-        entry: uvx ty check
-        language: system
-        types: [python]
-        pass_filenames: false
-        always_run: true
+  # Type checking is intentionally NOT a pre-commit hook. ty is pre-1.0 and
+  # its default environment resolution surfaces unresolved-import noise that
+  # made an `always_run` ty hook fail on every commit (so nobody enabled
+  # pre-commit). Run type checks in CI instead, where the venv is configured.
 
   # JSON validation
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -50,13 +44,7 @@ repos:
       - id: check-merge-conflict
       - id: check-case-conflict
 
-  # Validate agents using our custom script
-  - repo: local
-    hooks:
-      - id: validate-agents
-        name: Validate agent JSON files
-        entry: uv run python scripts/validate_agent.py
-        language: system
-        files: ^agents/.*\.json$
-        pass_filenames: true
+  # (Removed: the `validate-agents` hook globbed `agents/*.json` and ran
+  #  scripts/validate_agent.py — both deleted when the "Git as database" model
+  #  was replaced by the live API + PostgreSQL backend.)
 


### PR DESCRIPTION
Two pre-commit hooks were broken, which is why `pre-commit` wasn't being run locally (and why lint drift like the scripts/ and client-python/ findings accumulated):

- **`validate-agents`** — globbed `^agents/.*\.json$` and ran `scripts/validate_agent.py`. Both the `agents/` directory and that script were removed when the "Git as database" model was replaced by the live API + PostgreSQL backend (per CLAUDE.md). Dead hook.
- **`ty-check`** — `always_run: true` running `uvx ty check` over the whole tree. ty is pre-1.0 and its default environment resolution surfaces ~150 unresolved-import diagnostics (env not pointed at `.venv`), so the hook **failed on every commit**. Removed; type checking belongs in CI where the venv is configured (tracked in #141).

Kept: black, ruff (+ruff-format), JSON validation, and the general hygiene hooks.

Root-level config file, not in any deploy trigger path → no production deploy.