### PR TITLE
fix(security): require admin key for agent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Base URL: `https://a2aregistry.org/api`
 | `/agents/register` | POST | Register agent by wellKnownURI |
 | `/agents` | GET | List/search agents |
 | `/agents/{id}` | GET | Get agent details |
-| `/agents/{id}` | PUT | Re-fetch and update agent from wellKnownURI |
+| `/agents/{id}` | PUT | Re-fetch and update agent from wellKnownURI (admin key required) |
 | `/agents/{id}` | DELETE | Remove agent (ownership verified) |
 | `/agents/{id}/health` | GET | Get health status |
 | `/agents/{id}/uptime` | GET | Get uptime metrics |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -399,7 +399,11 @@ async def get_agent(agent_id: UUID):
 
 
 @router.put("/agents/{agent_id}", response_model=AgentPublic)
-async def update_agent(agent_id: UUID, request: Request):
+async def update_agent(
+    agent_id: UUID,
+    request: Request,
+    x_admin_key: Optional[str] = Header(default=None),
+):
     """
     Re-fetch and update an agent's metadata from its wellKnownURI.
 
@@ -409,6 +413,7 @@ async def update_agent(agent_id: UUID, request: Request):
     URL is fetched, validated, and persisted on success. With no body the
     existing URI is used (backward compatible).
     """
+    _require_admin(x_admin_key)
     track_api_query("PUT /agents/{id}", agent_id=str(agent_id))
 
     agent_repo = AgentRepository(db)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -234,23 +234,67 @@ def test_update_agent_success(client):
     updated_card = {**MOCK_AGENT_CARD, "name": "Updated Agent"}
 
     with patch("app.main.AgentRepository") as mock_repo, \
-         patch("app.main.fetch_agent_card", return_value=(updated_card, None)):
+         patch("app.main.fetch_agent_card", return_value=(updated_card, None)), \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
         instance.update = AsyncMock(return_value=_make_agent_in_db())
 
-        response = client.put(f"/agents/{MOCK_UUID}")
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 200
 
 
+def test_update_agent_requires_admin(client):
+    """PUT without admin key returns 403 before repository or fetch work."""
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.fetch_agent_card") as mock_fetch:
+        response = client.put(f"/agents/{MOCK_UUID}")
+
+    assert response.status_code == 403
+    mock_repo.assert_not_called()
+    mock_fetch.assert_not_called()
+
+
+def test_update_agent_wrong_admin_key(client):
+    """PUT with wrong admin key returns 403 before repository or fetch work."""
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.fetch_agent_card") as mock_fetch, \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
+
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            headers={"X-Admin-Key": "wrong-key"},
+        )
+
+    assert response.status_code == 403
+    mock_repo.assert_not_called()
+    mock_fetch.assert_not_called()
+
+
 def test_update_agent_not_found(client):
     """PUT on nonexistent agent returns 404."""
-    with patch("app.main.AgentRepository") as mock_repo:
+    with patch("app.main.AgentRepository") as mock_repo, \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=None)
 
-        response = client.put(f"/agents/{MOCK_UUID}")
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 404
 
@@ -260,11 +304,18 @@ def test_update_agent_fetch_fails(client):
     existing = _make_agent_public()
 
     with patch("app.main.AgentRepository") as mock_repo, \
-         patch("app.main.fetch_agent_card", return_value=(None, "Timeout")):
+         patch("app.main.fetch_agent_card", return_value=(None, "Timeout")), \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
 
-        response = client.put(f"/agents/{MOCK_UUID}")
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 400
     assert "Timeout" in response.json()["detail"]
@@ -289,7 +340,11 @@ def test_update_agent_uses_body_well_known_uri(client):
     with patch("app.main.AgentRepository") as mock_repo, \
          patch("app.main.validate_well_known_uri", return_value=[]), \
          patch("app.main.fetch_agent_card", return_value=(updated_card, None)) as mock_fetch, \
-         patch("app.main._agent_create_from_card") as mock_build:
+         patch("app.main._agent_create_from_card") as mock_build, \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
         instance.get_by_well_known_uri = AsyncMock(return_value=None)
@@ -297,7 +352,11 @@ def test_update_agent_uses_body_well_known_uri(client):
         instance.update = AsyncMock(return_value=_make_agent_in_db())
         mock_build.return_value = _make_agent_in_db()
 
-        response = client.put(f"/agents/{MOCK_UUID}", json={"wellKnownURI": NEW_URI})
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            json={"wellKnownURI": NEW_URI},
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 200
     # The NEW url was fetched — not the stale existing one.
@@ -311,12 +370,19 @@ def test_update_agent_no_body_refetches_existing(client):
     existing = _make_agent_public()
 
     with patch("app.main.AgentRepository") as mock_repo, \
-         patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)) as mock_fetch:
+         patch("app.main.fetch_agent_card", return_value=(MOCK_AGENT_CARD, None)) as mock_fetch, \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
         instance.update = AsyncMock(return_value=_make_agent_in_db())
 
-        response = client.put(f"/agents/{MOCK_UUID}")
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 200
     mock_fetch.assert_called_once_with(str(existing.wellKnownURI))
@@ -328,12 +394,20 @@ def test_update_agent_body_uri_conflict(client):
     other = _make_agent_in_db(id=UUID(OTHER_UUID), name="Other Agent")
 
     with patch("app.main.AgentRepository") as mock_repo, \
-         patch("app.main.validate_well_known_uri", return_value=[]):
+         patch("app.main.validate_well_known_uri", return_value=[]), \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
         instance.get_by_well_known_uri = AsyncMock(return_value=other)
 
-        response = client.put(f"/agents/{MOCK_UUID}", json={"wellKnownURI": NEW_URI})
+        response = client.put(
+            f"/agents/{MOCK_UUID}",
+            json={"wellKnownURI": NEW_URI},
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
 
     assert response.status_code == 409
     assert OTHER_UUID in response.json()["detail"]


### PR DESCRIPTION
## Summary
- require `X-Admin-Key` for `PUT /agents/{id}`, matching the existing DELETE/admin-note contract
- enforce auth before telemetry, repository lookup, body parsing, or agent-card fetch work
- update existing PUT tests to authenticate when exercising update behavior
- document the API behavior change in README

## Tests
- PASS: uv run --extra dev pytest tests/test_endpoints.py::test_update_agent_requires_admin tests/test_endpoints.py::test_update_agent_wrong_admin_key tests/test_endpoints.py::test_update_agent_success tests/test_endpoints.py::test_update_agent_not_found tests/test_endpoints.py::test_update_agent_fetch_fails tests/test_endpoints.py::test_update_agent_uses_body_well_known_uri tests/test_endpoints.py::test_update_agent_no_body_refetches_existing tests/test_endpoints.py::test_update_agent_body_uri_conflict -q
- PASS: uv run --extra dev ruff check app/main.py tests/test_endpoints.py
- PASS: uv run --extra dev pytest -q (136 passed)

## Fail-on-old check
Keeping the new auth tests but restoring old backend/app/main.py makes unauthenticated/wrong-key PUT tests fail: the old handler proceeds into repository/fetch code and returns 500 under the test mocks instead of 403 before any work.

## API behavior change
`PUT /agents/{id}` now requires the admin API key in `X-Admin-Key`. Unauthenticated and wrong-key requests return 403.

This intentionally makes agent URL updates admin-only until the registry has a per-agent ownership token model. External agent owners who need to repoint a dead `wellKnownURI` will need maintainer assistance.
