### PR TITLE
test: authenticate PUT SSRF regression

### DIFF
--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -343,7 +343,11 @@ def test_update_agent_rejects_private_body_well_known_uri(client):
     existing = _make_agent_public()
 
     with patch("app.main.AgentRepository") as mock_repo, \
-         patch("app.main.validate_well_known_uri", return_value=[]):
+         patch("app.main.validate_well_known_uri", return_value=[]), \
+         patch("app.main.settings") as mock_settings:
+        mock_settings.admin_api_key = "test-admin-key"
+        mock_settings.rate_limit_enabled = True
+        mock_settings.cors_origins = ["*"]
         instance = mock_repo.return_value
         instance.get_by_id = AsyncMock(return_value=existing)
         instance.get_by_well_known_uri = AsyncMock(return_value=None)
@@ -352,6 +356,7 @@ def test_update_agent_rejects_private_body_well_known_uri(client):
         response = client.put(
             f"/agents/{MOCK_UUID}",
             json={"wellKnownURI": "http://127.0.0.1/.well-known/agent.json"},
+            headers={"X-Admin-Key": "test-admin-key"},
         )
 
     assert response.status_code == 400


### PR DESCRIPTION
## Summary
- fix the only test composition break after #146 + #148 landed on main
- authenticate `test_update_agent_rejects_private_body_well_known_uri` so it reaches the centralized SSRF guard instead of stopping at PUT admin auth

## Tests
- PASS: `uv run --extra dev pytest tests/test_endpoints.py::test_update_agent_rejects_private_body_well_known_uri tests/test_endpoints.py::test_update_agent_requires_admin tests/test_endpoints.py::test_update_agent_wrong_admin_key -q` (3 passed)
- PASS: `uv run --extra dev ruff check tests/test_endpoints.py`
- PASS: `uv run --extra dev pytest -q` (149 passed)

## Context
The failed main workflow after #148 was test-only: the PUT SSRF regression test expected to exercise the card-fetch guard, but it did not pass `X-Admin-Key`, so the newly added auth guard correctly returned 403 first.
