### PR TITLE
chore: restore PR CI hygiene

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -33,7 +33,7 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
 
       - uses: google-github-actions/auth@v2
@@ -126,7 +126,7 @@ jobs:
       name: production
       url: https://a2aregistry.org
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,31 @@
+name: PR CI
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/pr-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend tests and lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          working-directory: backend
+
+      - name: Run tests
+        run: uv run --extra dev pytest
+
+      - name: Run ruff
+        run: uv run --extra dev ruff check app tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -22,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -35,17 +36,19 @@ jobs:
       working-directory: website
       run: npm ci
     
-    - name: Build React website
+    - name: Build Astro website
       working-directory: website
+      env:
+        ASTRO_OUT_DIR: dist
       run: |
-        echo "🔄 Building React website..."
+        echo "Building Astro website..."
         npm run build
-        echo "✅ Website built successfully"
+        echo "Website built successfully"
     
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
-        path: docs/
+        path: website/dist/
 
   deploy-pages:
     needs: build-website
@@ -59,7 +62,7 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5
 
   publish-client:
     runs-on: ubuntu-latest
@@ -67,10 +70,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     
@@ -100,8 +103,8 @@ jobs:
     - name: Display package info
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
-        echo "📦 Python client package built successfully"
-        echo "📋 This is a dry run - package was not published"
-        echo "🏷️  To publish, create a tag: git tag v0.1.0 && git push --tags"
+        echo "Python client package built successfully"
+        echo "This is a dry run - package was not published"
+        echo "To publish, create a tag: git tag v0.1.0 && git push --tags"
         echo ""
         ls -la client-python/dist/


### PR DESCRIPTION
## Summary
- add PR-triggered backend CI for pytest plus ruff on the backend package/tests
- update GitHub Actions Node-runtime pins: checkout v6, setup-node v6, upload-pages-artifact v4, deploy-pages v5
- unify setup-uv usage on v7 and publish the Astro Pages build from website/dist

## Notes
- `deploy-backend.yml` was touched only for `actions/checkout@v6`; no deploy triggers, deploy jobs, image publishing, secrets, or environments were changed.
- `ruff check .` currently fails on existing `backend/worker.py` lint issues, so the new PR CI runs `ruff check app tests` to keep the baseline green without app-code changes.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- `cd backend && uv run --extra dev pytest && uv run --extra dev ruff check app tests`
- `cd website && ASTRO_OUT_DIR=dist npm run build && test -d dist`
