### PR TITLE
fix(worker): refresh displayed card metadata + clear stale recovery notes

### DIFF
--- a/backend/app/agent_card.py
+++ b/backend/app/agent_card.py
@@ -1,0 +1,87 @@
+"""Helpers for turning a fetched agent card (dict) into an AgentCreate.
+
+Shared by the registration/PUT routes (app.main) and the background worker
+(worker.py) so both build the stored agent record from a live card exactly the
+same way. Supports both A2A v0.3 (top-level url/protocolVersion) and v1.0
+(interfaces[].url / supportedInterfaces[].url) card formats.
+"""
+
+from typing import Any, Optional
+
+from .models import AgentCreate
+
+
+def extract_agent_url(card: dict[str, Any]) -> str:
+    """Extract the primary agent URL from a card, supporting v0.3 and v1.0.
+
+    v0.3: top-level ``url`` field.
+    v1.0: ``interfaces[0].url`` (or ``supportedInterfaces[0].url``).
+    """
+    if "url" in card:
+        return card["url"]
+    for key in ("interfaces", "supportedInterfaces"):
+        interfaces = card.get(key)
+        if isinstance(interfaces, list) and interfaces:
+            url = interfaces[0].get("url")
+            if url:
+                return url
+    raise KeyError("Agent card has no 'url' field and no 'interfaces[].url' — cannot determine endpoint")
+
+
+def extract_protocol_version(card: dict[str, Any]) -> str:
+    """Extract protocol version, supporting both v0.3 and v1.0 formats."""
+    if "protocolVersion" in card:
+        return card["protocolVersion"]
+    for key in ("interfaces", "supportedInterfaces"):
+        interfaces = card.get(key)
+        if isinstance(interfaces, list) and interfaces:
+            pv = interfaces[0].get("protocolVersion")
+            if pv:
+                return pv
+    return "unknown"
+
+
+def agent_create_from_card(
+    agent_card: dict[str, Any],
+    well_known_uri: str,
+    *,
+    author_override: Optional[str] = None,
+    author_fallback: str = "Unknown",
+) -> AgentCreate:
+    """Build an AgentCreate from a fetched agent card dict.
+
+    Supports both v0.3 and v1.0 A2A Protocol agent card formats.
+
+    Raises ValueError if the card is missing required fields or is otherwise
+    malformed. Callers in HTTP context map this to a 400; the worker logs and
+    skips. (Keeping this transport-agnostic is why it raises ValueError rather
+    than HTTPException.)
+    """
+    try:
+        # v1.0 moves supportsAuthenticatedExtendedCard into capabilities.extendedAgentCard
+        capabilities = agent_card.get(
+            "capabilities",
+            {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False},
+        )
+
+        return AgentCreate(
+            protocolVersion=extract_protocol_version(agent_card),
+            name=agent_card["name"],
+            description=agent_card.get("description", ""),
+            author=author_override or (agent_card.get("provider") or {}).get("organization", author_fallback),
+            wellKnownURI=well_known_uri,
+            url=extract_agent_url(agent_card),
+            version=agent_card.get("version", "1.0.0"),
+            provider=agent_card.get("provider"),
+            documentationUrl=agent_card.get("documentationUrl"),
+            capabilities=capabilities,
+            defaultInputModes=agent_card.get("defaultInputModes", ["text/plain"]),
+            defaultOutputModes=agent_card.get("defaultOutputModes", ["text/plain"]),
+            skills=agent_card.get("skills", []),
+        )
+    except KeyError as e:
+        raise ValueError(f"Invalid agent card: missing {e}")
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(f"Invalid agent card format: {e}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from .agent_card import agent_create_from_card
 from .config import settings
 from .database import db
 from .mcp_server import mcp
@@ -43,36 +44,6 @@ from .validators import validate_well_known_uri
 limiter = Limiter(key_func=get_remote_address, enabled=settings.rate_limit_enabled)
 
 
-def _extract_agent_url(card: dict[str, Any]) -> str:
-    """Extract the primary agent URL from a card, supporting both v0.3 and v1.0 formats.
-
-    v0.3: top-level ``url`` field
-    v1.0: ``interfaces[0].url`` (or ``supportedInterfaces[0].url``)
-    """
-    if "url" in card:
-        return card["url"]
-    for key in ("interfaces", "supportedInterfaces"):
-        interfaces = card.get(key)
-        if isinstance(interfaces, list) and interfaces:
-            url = interfaces[0].get("url")
-            if url:
-                return url
-    raise KeyError("Agent card has no 'url' field and no 'interfaces[].url' — cannot determine endpoint")
-
-
-def _extract_protocol_version(card: dict[str, Any]) -> str:
-    """Extract protocol version, supporting both v0.3 and v1.0 formats."""
-    if "protocolVersion" in card:
-        return card["protocolVersion"]
-    for key in ("interfaces", "supportedInterfaces"):
-        interfaces = card.get(key)
-        if isinstance(interfaces, list) and interfaces:
-            pv = interfaces[0].get("protocolVersion")
-            if pv:
-                return pv
-    return "unknown"
-
-
 def _agent_create_from_card(
     agent_card: dict[str, Any],
     well_known_uri: str,
@@ -80,34 +51,21 @@ def _agent_create_from_card(
     author_override: Optional[str] = None,
     author_fallback: str = "Unknown",
 ) -> AgentCreate:
-    """Build an AgentCreate from a fetched agent card dict.
+    """HTTP wrapper around agent_card.agent_create_from_card.
 
-    Supports both v0.3 and v1.0 A2A Protocol agent card formats.
-    Raises HTTPException(400) if the card is missing required fields.
+    Maps the transport-agnostic ValueError to a 400 so registration/PUT keep
+    their existing API contract. The actual card-parsing logic is shared with
+    the worker (see app.agent_card).
     """
     try:
-        # v1.0 moves supportsAuthenticatedExtendedCard into capabilities.extendedAgentCard
-        capabilities = agent_card.get("capabilities", {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False})
-
-        return AgentCreate(
-            protocolVersion=_extract_protocol_version(agent_card),
-            name=agent_card["name"],
-            description=agent_card.get("description", ""),
-            author=author_override or (agent_card.get("provider") or {}).get("organization", author_fallback),
-            wellKnownURI=well_known_uri,
-            url=_extract_agent_url(agent_card),
-            version=agent_card.get("version", "1.0.0"),
-            provider=agent_card.get("provider"),
-            documentationUrl=agent_card.get("documentationUrl"),
-            capabilities=capabilities,
-            defaultInputModes=agent_card.get("defaultInputModes", ["text/plain"]),
-            defaultOutputModes=agent_card.get("defaultOutputModes", ["text/plain"]),
-            skills=agent_card.get("skills", []),
+        return agent_create_from_card(
+            agent_card,
+            well_known_uri,
+            author_override=author_override,
+            author_fallback=author_fallback,
         )
-    except KeyError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid agent card: missing {e}")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Invalid agent card format: {e}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 def _make_mcp_app():

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -332,6 +332,50 @@ class AgentRepository:
             agent_id,
         )
 
+    # Displayed-metadata columns the background health worker is allowed to
+    # refresh in place. Deliberately excludes everything else (provider,
+    # capabilities, skills, icon, security, securitySchemes, auth flags, modes)
+    # so a name/version drift can never NULL out fields the worker doesn't
+    # re-derive. Maps public field name -> DB column.
+    _WORKER_REFRESHABLE_COLUMNS = {
+        "name": "name",
+        "version": "version",
+        "url": "url",
+        "protocolVersion": "protocol_version",
+        "description": "description",
+    }
+
+    async def update_card_metadata(self, agent_id: UUID, fields: dict[str, str]) -> bool:
+        """Patch only the supplied displayed-metadata columns, preserving all others.
+
+        Used by the health worker to keep name/version/url/protocolVersion/
+        description in sync with the live card without touching capabilities,
+        skills, security, icon, or auth metadata (which a partial card fetch
+        cannot safely re-derive). Unknown keys are rejected to keep the write
+        surface locked to the whitelist. Returns True if a row was updated.
+        """
+        columns = {}
+        for key, value in fields.items():
+            if key not in self._WORKER_REFRESHABLE_COLUMNS:
+                raise ValueError(f"Field '{key}' is not worker-refreshable")
+            columns[self._WORKER_REFRESHABLE_COLUMNS[key]] = value
+        if not columns:
+            return False
+
+        set_fragments = []
+        params: list = []
+        for idx, (column, value) in enumerate(columns.items(), start=1):
+            set_fragments.append(f"{column} = ${idx}")
+            params.append(value)
+        set_clause = ", ".join(set_fragments)
+        params.append(agent_id)
+        result = await self.db.execute(
+            f"UPDATE agents SET {set_clause}, updated_at = NOW() "
+            f"WHERE id = ${len(params)} AND hidden = false",
+            *params,
+        )
+        return result == "UPDATE 1"
+
     async def update(self, agent_id: UUID, agent: AgentCreate) -> Optional[AgentInDB]:
         """Update an existing agent's metadata from a re-fetched agent card"""
         query = """

--- a/backend/tests/test_worker_refresh.py
+++ b/backend/tests/test_worker_refresh.py
@@ -52,6 +52,24 @@ def _live_card(**overrides):
     return card
 
 
+def _live_card_v1(iface_url="https://new.example/messages", iface_proto="1.0", **overrides):
+    """A v1.0-shaped card: no top-level url/protocolVersion; both live nested in
+    interfaces[0]. _normalise_fields lifts them to top level for value extraction,
+    but presence must be detected from this raw nested shape."""
+    card = {
+        "name": "inferGONKA",
+        "description": "Spend less. Build more.",
+        "version": "1.3.0",
+        "capabilities": {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
+        "interfaces": [{"url": iface_url, "protocolVersion": iface_proto}],
+    }
+    card.update(overrides)
+    return card
+
+
 # ── refresh_agent_metadata ──────────────────────────────────────────────────
 
 
@@ -261,6 +279,67 @@ async def test_refresh_skips_unknown_protocol_version_sentinel():
     assert changed is True  # name changed
     _, fields = repo.update_card_metadata.await_args.args
     assert "protocolVersion" not in fields
+
+
+# ── v1.0 nested-interface presence (PR #154 re-review: still-blocking) ───────
+
+
+async def test_refresh_v1_interface_only_url_and_protocol_drift_refreshes():
+    """STILL-BLOCKING: a strict-valid v1.0 card whose url + protocolVersion live
+    ONLY in interfaces[0] must still refresh when they drift. Presence detection
+    has to look inside the nested interface, not just top-level string keys."""
+    stored = _stored_agent(
+        url="https://old.example/messages",
+        protocolVersion="0.3.0",
+        # name/version/description match so the ONLY drift is the nested fields.
+        name="inferGONKA",
+        version="1.3.0",
+        description="Spend less. Build more.",
+    )
+    repo = _metadata_repo()
+    card = _live_card_v1(iface_url="https://new.example/messages", iface_proto="1.0")
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is True
+    repo.update.assert_not_awaited()
+    _, fields = repo.update_card_metadata.await_args.args
+    assert fields["url"] == "https://new.example/messages"
+    assert fields["protocolVersion"] == "1.0"
+    # Only the nested fields drifted, so only those are written.
+    assert set(fields) == {"url", "protocolVersion"}
+
+
+async def test_refresh_v1_interface_missing_nested_values_writes_no_sentinel():
+    """A v1.0 card whose interface lacks url/protocolVersion (and has only a
+    top-level url) must not write the 'unknown' protocolVersion sentinel, and
+    must not blank a stored url it can't re-derive."""
+    stored = _stored_agent(
+        url="https://top.example/x",
+        protocolVersion="0.3.0",
+        name="Old Name",  # force a real change so a write happens at all
+        version="1.3.0",
+        description="Spend less. Build more.",
+    )
+    repo = _metadata_repo()
+    card = {
+        "name": "inferGONKA",
+        "description": "Spend less. Build more.",
+        "version": "1.3.0",
+        "url": "https://top.example/x",  # top-level url present (unchanged)
+        "capabilities": {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
+        "interfaces": [{"transport": "JSONRPC"}],  # no url, no protocolVersion
+    }
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is True  # name changed
+    _, fields = repo.update_card_metadata.await_args.args
+    assert fields == {"name": "inferGONKA"}
+    assert "protocolVersion" not in fields  # never the 'unknown' sentinel
 
 
 # ── refresh_recovery_notes ──────────────────────────────────────────────────

--- a/backend/tests/test_worker_refresh.py
+++ b/backend/tests/test_worker_refresh.py
@@ -9,7 +9,10 @@ registration values forever.
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 import worker
+from app.repositories import AgentRepository
 from app.smoke_test import CATEGORY_NOTES
 
 
@@ -52,23 +55,53 @@ def _live_card(**overrides):
 # ── refresh_agent_metadata ──────────────────────────────────────────────────
 
 
+def _metadata_repo():
+    """Repo stub for metadata refresh. update_card_metadata returns True (a row
+    was updated); the full-record update() must NEVER be called by the worker."""
+    return SimpleNamespace(
+        update_card_metadata=AsyncMock(return_value=True),
+        update=AsyncMock(),
+    )
+
+
 async def test_refresh_updates_when_name_and_version_drift():
-    """The #153 scenario: live card renamed + version-bumped → record is rewritten."""
+    """The #153 scenario: live card renamed + version-bumped → displayed fields patched."""
     stored = _stored_agent()
-    repo = SimpleNamespace(update=AsyncMock())
+    repo = _metadata_repo()
 
     changed = await worker.refresh_agent_metadata(stored, _live_card(), repo)
 
     assert changed is True
-    repo.update.assert_awaited_once()
-    agent_id_arg, candidate = repo.update.await_args.args
+    # Must use the column-scoped patch, never the full-record update().
+    repo.update.assert_not_awaited()
+    repo.update_card_metadata.assert_awaited_once()
+    agent_id_arg, fields = repo.update_card_metadata.await_args.args
     assert agent_id_arg == stored.id
-    assert candidate.name == "inferGONKA"
-    assert candidate.version == "1.3.0"
-    assert candidate.protocolVersion == "0.3.0"
-    assert str(candidate.url) == "https://a2a.gogonka.com/messages"
-    # The worker must never rewrite the discovery URL.
-    assert str(candidate.wellKnownURI) == stored.wellKnownURI
+    assert fields["name"] == "inferGONKA"
+    assert fields["version"] == "1.3.0"
+    assert fields["protocolVersion"] == "0.3.0"
+    assert fields["url"] == "https://a2a.gogonka.com/messages"
+    # Only the displayed whitelist is ever written — nothing else.
+    assert set(fields).issubset(set(worker._REFRESHED_FIELDS))
+
+
+async def test_refresh_only_writes_changed_fields():
+    """A pure rename patches only `name`, leaving unchanged fields out of the write."""
+    card = _live_card()
+    stored = _stored_agent(
+        name="Old Name",
+        version=card["version"],
+        url=card["url"],
+        protocolVersion=card["protocolVersion"],
+        description=card["description"],
+    )
+    repo = _metadata_repo()
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is True
+    _, fields = repo.update_card_metadata.await_args.args
+    assert fields == {"name": "inferGONKA"}
 
 
 async def test_refresh_noop_when_card_matches_stored():
@@ -81,18 +114,18 @@ async def test_refresh_noop_when_card_matches_stored():
         protocolVersion=card["protocolVersion"],
         description=card["description"],
     )
-    repo = SimpleNamespace(update=AsyncMock())
+    repo = _metadata_repo()
 
     changed = await worker.refresh_agent_metadata(stored, card, repo)
 
     assert changed is False
-    repo.update.assert_not_awaited()
+    repo.update_card_metadata.assert_not_awaited()
 
 
 async def test_refresh_normalises_snake_case_card():
     """Cards using snake_case field names (SDK style) still refresh correctly."""
     stored = _stored_agent()
-    repo = SimpleNamespace(update=AsyncMock())
+    repo = _metadata_repo()
     snake_card = {
         "protocol_version": "0.3.0",
         "name": "inferGONKA",
@@ -108,9 +141,126 @@ async def test_refresh_normalises_snake_case_card():
     changed = await worker.refresh_agent_metadata(stored, snake_card, repo)
 
     assert changed is True
-    _, candidate = repo.update.await_args.args
-    assert candidate.protocolVersion == "0.3.0"
-    assert candidate.version == "1.3.0"
+    _, fields = repo.update_card_metadata.await_args.args
+    assert fields["protocolVersion"] == "0.3.0"
+    assert fields["version"] == "1.3.0"
+
+
+# ── data-integrity guards (PR #154 review: blocking findings) ────────────────
+
+
+async def test_refresh_card_missing_version_never_clobbers_with_default():
+    """BLOCKING #1: a card missing `version` must NOT overwrite the stored version
+    with a default ('1.0.0').
+
+    Note: the registry's strict validator does NOT require `version`, so the
+    strict gate alone wouldn't catch this — the real safeguard is that the field
+    extractor omits absent fields entirely. Here the card matches the stored
+    record on everything *except* the (absent) version, so the write is empty."""
+    card = _live_card()
+    stored = _stored_agent(
+        name=card["name"],
+        version="1.1.0",  # stored has a real version
+        url=card["url"],
+        protocolVersion=card["protocolVersion"],
+        description=card["description"],
+    )
+    del card["version"]  # live card dropped its version
+    repo = _metadata_repo()
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is False  # version omitted, nothing else drifted
+    repo.update_card_metadata.assert_not_awaited()
+    repo.update.assert_not_awaited()
+
+
+async def test_refresh_present_field_extraction_never_synthesises_version():
+    """Defence-in-depth for BLOCKING #1: when other fields drift but `version` is
+    absent from the card, the extractor omits `version` rather than supplying a
+    default — so the stored version survives while the real change is written."""
+    stored = _stored_agent(version="1.1.0", name="Old Name")
+    repo = _metadata_repo()
+    card = _live_card()
+    del card["version"]
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is True  # name changed
+    _, fields = repo.update_card_metadata.await_args.args
+    assert "version" not in fields  # never synthesised
+    assert fields["name"] == "inferGONKA"
+
+
+async def test_refresh_preserves_security_icon_auth_via_scoped_patch():
+    """BLOCKING #2: a name/version drift must not NULL out security/icon/auth
+    fields. The worker writes via the column-scoped patch, whose whitelist
+    excludes those columns entirely — so they can never be touched here."""
+    stored = _stored_agent()
+    repo = _metadata_repo()
+
+    await worker.refresh_agent_metadata(stored, _live_card(), repo)
+
+    _, fields = repo.update_card_metadata.await_args.args
+    for protected in ("securitySchemes", "security", "iconUrl",
+                      "supportsAuthenticatedExtendedCard", "capabilities", "skills", "provider"):
+        assert protected not in fields
+    # And the repo whitelist itself rejects them.
+    assert "security_schemes" not in AgentRepository._WORKER_REFRESHABLE_COLUMNS.values()
+    assert "icon_url" not in AgentRepository._WORKER_REFRESHABLE_COLUMNS.values()
+
+
+async def test_refresh_skips_non_conformant_card():
+    """BLOCKING #1: a degraded-but-parseable card (strict conformance errors)
+    must not refresh displayed metadata at all."""
+    stored = _stored_agent()
+    repo = _metadata_repo()
+
+    changed = await worker.refresh_agent_metadata(
+        stored, _live_card(), repo, conformance_errors=["some strict error"],
+    )
+
+    assert changed is False
+    repo.update_card_metadata.assert_not_awaited()
+
+
+async def test_refresh_no_churn_on_bare_host_url_trailing_slash():
+    """A card url of 'https://x.com' must not rewrite the stored 'https://x.com/'
+    every cycle. The candidate url is canonicalised to HttpUrl form, matching how
+    the stored value round-trips, so no spurious diff occurs."""
+    card = _live_card(url="https://example.com")  # no trailing slash on the card
+    stored = _stored_agent(
+        name=card["name"],
+        version=card["version"],
+        url="https://example.com/",  # stored as HttpUrl renders it
+        protocolVersion=card["protocolVersion"],
+        description=card["description"],
+    )
+    repo = _metadata_repo()
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is False
+    repo.update_card_metadata.assert_not_awaited()
+
+
+async def test_refresh_skips_unknown_protocol_version_sentinel():
+    """A card with no protocolVersion (extractor returns 'unknown') must not
+    overwrite a stored real protocolVersion with the sentinel."""
+    stored = _stored_agent(protocolVersion="0.3.0", name="Old Name")
+    repo = _metadata_repo()
+    card = _live_card()
+    del card["protocolVersion"]
+
+    # Without protocolVersion the card fails strict validation, so force the gate
+    # open to isolate the sentinel guard.
+    changed = await worker.refresh_agent_metadata(
+        stored, card, repo, conformance_errors=[],
+    )
+
+    assert changed is True  # name changed
+    _, fields = repo.update_card_metadata.await_args.args
+    assert "protocolVersion" not in fields
 
 
 # ── refresh_recovery_notes ──────────────────────────────────────────────────
@@ -169,3 +319,51 @@ async def test_recovery_noop_when_no_notes():
 
     assert changed is False
     repo.update_maintainer_notes.assert_not_awaited()
+
+
+# ── AgentRepository.update_card_metadata (column-scoped patch) ────────────────
+
+
+async def test_update_card_metadata_writes_only_whitelisted_columns():
+    """The patch SQL touches only the mapped columns + updated_at, never the
+    full card. This is the structural guarantee behind PR #154 BLOCKING #2."""
+    db = SimpleNamespace(execute=AsyncMock(return_value="UPDATE 1"))
+    repo = AgentRepository(db)
+
+    written = await repo.update_card_metadata(
+        "abc", {"name": "New", "version": "2.0.0", "protocolVersion": "0.3.0"}
+    )
+
+    assert written is True
+    sql = db.execute.await_args.args[0]
+    assert "name = $1" in sql and "version = $2" in sql and "protocol_version = $3" in sql
+    assert "updated_at = NOW()" in sql
+    # Columns the worker must never write must be absent from the statement.
+    for forbidden in ("capabilities", "skills", "security", "security_schemes",
+                      "icon_url", "supports_authenticated_extended_card",
+                      "provider", "well_known_uri"):
+        assert forbidden not in sql
+    # Values are bound positionally; the id is the last parameter.
+    assert db.execute.await_args.args[-1] == "abc"
+
+
+async def test_update_card_metadata_rejects_unknown_field():
+    """A non-whitelisted key is rejected loudly rather than silently widening the write."""
+    db = SimpleNamespace(execute=AsyncMock())
+    repo = AgentRepository(db)
+
+    with pytest.raises(ValueError, match="not worker-refreshable"):
+        await repo.update_card_metadata("abc", {"securitySchemes": {"evil": 1}})
+
+    db.execute.assert_not_awaited()
+
+
+async def test_update_card_metadata_noop_on_empty():
+    """No SQL is issued when there is nothing to write."""
+    db = SimpleNamespace(execute=AsyncMock())
+    repo = AgentRepository(db)
+
+    written = await repo.update_card_metadata("abc", {})
+
+    assert written is False
+    db.execute.assert_not_awaited()

--- a/backend/tests/test_worker_refresh.py
+++ b/backend/tests/test_worker_refresh.py
@@ -1,0 +1,171 @@
+"""Tests for the worker's card-metadata and recovery-note refresh logic (#150, #153).
+
+These cover the systemic gap where the health worker refreshed health and
+conformance but never re-synced the *displayed* card metadata (name/version/
+url/protocolVersion), so a renamed or version-bumped agent stayed frozen at its
+registration values forever.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import worker
+from app.smoke_test import CATEGORY_NOTES
+
+
+def _stored_agent(**overrides):
+    """A minimal stand-in for the stored AgentPublic record the worker reads.
+
+    Only the attributes the refresh helpers touch are populated.
+    """
+    base = dict(
+        id="95e89fba-1765-4c16-a8c5-0a239dbfd29e",
+        name="Gonka Cost Optimizer",
+        version="1.1.0",
+        url="https://a2a.gogonka.com/",
+        protocolVersion="unknown",
+        description="old description",
+        author="Gonka",
+        wellKnownURI="https://a2a.gogonka.com/.well-known/agent.json",
+        maintainer_notes=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _live_card(**overrides):
+    card = {
+        "protocolVersion": "0.3.0",
+        "name": "inferGONKA",
+        "description": "Spend less. Build more.",
+        "url": "https://a2a.gogonka.com/messages",
+        "version": "1.3.0",
+        "capabilities": {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
+    }
+    card.update(overrides)
+    return card
+
+
+# ── refresh_agent_metadata ──────────────────────────────────────────────────
+
+
+async def test_refresh_updates_when_name_and_version_drift():
+    """The #153 scenario: live card renamed + version-bumped → record is rewritten."""
+    stored = _stored_agent()
+    repo = SimpleNamespace(update=AsyncMock())
+
+    changed = await worker.refresh_agent_metadata(stored, _live_card(), repo)
+
+    assert changed is True
+    repo.update.assert_awaited_once()
+    agent_id_arg, candidate = repo.update.await_args.args
+    assert agent_id_arg == stored.id
+    assert candidate.name == "inferGONKA"
+    assert candidate.version == "1.3.0"
+    assert candidate.protocolVersion == "0.3.0"
+    assert str(candidate.url) == "https://a2a.gogonka.com/messages"
+    # The worker must never rewrite the discovery URL.
+    assert str(candidate.wellKnownURI) == stored.wellKnownURI
+
+
+async def test_refresh_noop_when_card_matches_stored():
+    """No write (and no updated_at churn) when nothing drifted."""
+    card = _live_card()
+    stored = _stored_agent(
+        name=card["name"],
+        version=card["version"],
+        url=card["url"],
+        protocolVersion=card["protocolVersion"],
+        description=card["description"],
+    )
+    repo = SimpleNamespace(update=AsyncMock())
+
+    changed = await worker.refresh_agent_metadata(stored, card, repo)
+
+    assert changed is False
+    repo.update.assert_not_awaited()
+
+
+async def test_refresh_normalises_snake_case_card():
+    """Cards using snake_case field names (SDK style) still refresh correctly."""
+    stored = _stored_agent()
+    repo = SimpleNamespace(update=AsyncMock())
+    snake_card = {
+        "protocol_version": "0.3.0",
+        "name": "inferGONKA",
+        "description": "x",
+        "url": "https://a2a.gogonka.com/messages",
+        "version": "1.3.0",
+        "capabilities": {"streaming": False, "pushNotifications": False, "stateTransitionHistory": False},
+        "default_input_modes": ["text/plain"],
+        "default_output_modes": ["text/plain"],
+        "skills": [],
+    }
+
+    changed = await worker.refresh_agent_metadata(stored, snake_card, repo)
+
+    assert changed is True
+    _, candidate = repo.update.await_args.args
+    assert candidate.protocolVersion == "0.3.0"
+    assert candidate.version == "1.3.0"
+
+
+# ── refresh_recovery_notes ──────────────────────────────────────────────────
+
+
+async def test_recovery_clears_stale_system_failure_note():
+    """The #150/#153 stale-notes contradiction: a system 404 note is replaced on recovery."""
+    stored = _stored_agent(maintainer_notes=CATEGORY_NOTES["404"])
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "WORKING", repo)
+
+    assert changed is True
+    repo.update_maintainer_notes.assert_awaited_once_with(stored.id, CATEGORY_NOTES["WORKING"])
+
+
+async def test_recovery_preserves_human_authored_notes():
+    """A human-written note must never be overwritten by the worker."""
+    stored = _stored_agent(maintainer_notes="Hand-written note from the maintainer.")
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "WORKING", repo)
+
+    assert changed is False
+    repo.update_maintainer_notes.assert_not_awaited()
+
+
+async def test_recovery_noop_when_not_working():
+    """A still-failing probe leaves notes alone (they may carry the failure reason)."""
+    stored = _stored_agent(maintainer_notes=CATEGORY_NOTES["404"])
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "404", repo)
+
+    assert changed is False
+    repo.update_maintainer_notes.assert_not_awaited()
+
+
+async def test_recovery_noop_when_already_working_note():
+    """No redundant write when the note is already the WORKING note."""
+    stored = _stored_agent(maintainer_notes=CATEGORY_NOTES["WORKING"])
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "WORKING", repo)
+
+    assert changed is False
+    repo.update_maintainer_notes.assert_not_awaited()
+
+
+async def test_recovery_noop_when_no_notes():
+    """Empty notes need no change."""
+    stored = _stored_agent(maintainer_notes=None)
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "WORKING", repo)
+
+    assert changed is False
+    repo.update_maintainer_notes.assert_not_awaited()

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -63,6 +63,11 @@ def _canonical_url(value: str) -> str:
         return value
 
 
+def _raw_str(value) -> bool:
+    """True if `value` is a present, non-empty string."""
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _raw_has(raw_card: dict, *keys: str) -> bool:
     """True if the RAW card carries a present, non-empty string under any of the
     given key spellings.
@@ -72,11 +77,41 @@ def _raw_has(raw_card: dict, *keys: str) -> bool:
     so a normalised card always *looks* like it has a version even when the live
     card omitted it. Reading presence from the raw card is what stops a default
     from clobbering real stored data (PR #154 BLOCKING #1)."""
-    for key in keys:
-        value = raw_card.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-    return False
+    return any(_raw_str(raw_card.get(key)) for key in keys)
+
+
+def _first_interface(raw_card: dict) -> Optional[dict]:
+    """The first declared interface entry in a v1.0 card (interfaces[] or
+    supportedInterfaces[]), or None for a v0.3 (top-level url) card.
+
+    Mirrors how app.agent_card's extractors locate the interface so presence
+    detection and value extraction agree on the same source.
+    """
+    for key in ("interfaces", "supportedInterfaces"):
+        entries = raw_card.get(key)
+        if isinstance(entries, list) and entries and isinstance(entries[0], dict):
+            return entries[0]
+    return None
+
+
+def _raw_has_endpoint(raw_card: dict) -> bool:
+    """True if the RAW card declares a usable endpoint URL — top-level `url`
+    (v0.3) OR a nested interfaces[0].url (v1.0). A list under `interfaces` is
+    not itself a string, so _raw_has can't see it; this is the #127-class
+    top-level-vs-nested trap the worker must handle for v1.0 cards."""
+    if _raw_str(raw_card.get("url")):
+        return True
+    iface = _first_interface(raw_card)
+    return iface is not None and _raw_str(iface.get("url"))
+
+
+def _raw_has_protocol_version(raw_card: dict) -> bool:
+    """True if the RAW card declares a protocol version — top-level (either
+    spelling, v0.3) OR a nested interfaces[0].protocolVersion (v1.0)."""
+    if _raw_has(raw_card, "protocolVersion", "protocol_version"):
+        return True
+    iface = _first_interface(raw_card)
+    return iface is not None and _raw_str(iface.get("protocolVersion"))
 
 
 def _present_card_fields(raw_card: dict, normalised: dict) -> dict[str, str]:
@@ -84,8 +119,9 @@ def _present_card_fields(raw_card: dict, normalised: dict) -> dict[str, str]:
 
     Presence is decided from `raw_card` (so injected defaults never count);
     values come from `normalised` (so snake_case spellings and v0.3/v1.0 shape
-    differences are already resolved). A field absent from the raw card is
-    omitted entirely — never written with a default.
+    differences are already resolved by _normalise_fields, which lifts a v1.0
+    interfaces[0].url/protocolVersion to top level). A field absent from the raw
+    card is omitted entirely — never written with a default.
     """
     fields: dict[str, str] = {}
 
@@ -98,20 +134,19 @@ def _present_card_fields(raw_card: dict, normalised: dict) -> dict[str, str]:
     if _raw_has(raw_card, "description"):
         fields["description"] = normalised["description"]
 
-    # url present iff the card had a usable endpoint (top-level url or
-    # interfaces[].url). The extractor raises KeyError when neither exists.
-    if _raw_has(raw_card, "url", "interfaces", "supportedInterfaces"):
+    # url present iff the card declares an endpoint, top-level OR nested (v1.0).
+    if _raw_has_endpoint(raw_card):
         try:
             url = extract_agent_url(normalised)
-            if isinstance(url, str) and url.strip():
+            if _raw_str(url):
                 # Canonicalise so it compares/writes stably against the stored
                 # HttpUrl form (avoids per-cycle rewrites on a trailing slash).
                 fields["url"] = _canonical_url(url)
         except KeyError:
             pass
 
-    # protocolVersion: present under either spelling, or nested in interfaces.
-    if _raw_has(raw_card, "protocolVersion", "protocol_version", "interfaces", "supportedInterfaces"):
+    # protocolVersion present iff declared top-level OR nested (v1.0).
+    if _raw_has_protocol_version(raw_card):
         protocol_version = extract_protocol_version(normalised)
         # Sentinel 'unknown' means we couldn't actually read one — don't write it.
         if isinstance(protocol_version, str) and protocol_version not in ("", "unknown"):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -4,16 +4,16 @@
 import asyncio
 import time
 from pathlib import Path
-from uuid import UUID
 
 import aiohttp
 
+from app.agent_card import agent_create_from_card
 from app.config import settings
 from app.database import db
 from app.logging_config import configure_logging, get_logger
 from app.repositories import AgentRepository, HealthCheckRepository
-from app.smoke_test import TASK_PROBE_USER_AGENT, smoke_test
-from app.validators import validate_agent_card
+from app.smoke_test import CATEGORY_NOTES, TASK_PROBE_USER_AGENT, smoke_test
+from app.validators import _normalise_fields, validate_agent_card
 
 HEARTBEAT_FILE = Path("/tmp/worker-heartbeat")
 
@@ -30,9 +30,83 @@ configure_logging(json_logs=True)
 logger = get_logger(__name__)
 
 
+# Displayed card fields the worker keeps in sync with the live card. If any of
+# these drifts from what we have stored, we re-fetch the full record. Excludes
+# wellKnownURI (the worker never changes an agent's discovery URL — only the PUT
+# endpoint does that, with collision checks).
+_REFRESHED_FIELDS = ("name", "version", "url", "protocolVersion", "description")
+
+# System-generated maintainer notes the worker is allowed to overwrite once an
+# agent's task probe flips back to WORKING. Anything not authored by the
+# registry itself (i.e. a human-written note) is left untouched.
+_SYSTEM_AUTHORED_NOTES = frozenset(CATEGORY_NOTES.values())
+
+
+def _metadata_differs(stored, candidate) -> bool:
+    """True if any displayed field on the live card differs from what we store."""
+    for field in _REFRESHED_FIELDS:
+        if str(getattr(stored, field, None)) != str(getattr(candidate, field, None)):
+            return True
+    return False
+
+
+async def refresh_agent_metadata(stored, card_data: dict, agent_repo: AgentRepository) -> bool:
+    """Re-sync displayed card metadata (name/version/url/protocolVersion/...) from
+    the live card when it has drifted from what we store.
+
+    The health worker fetches the raw card directly (not via fetch_agent_card),
+    so we normalise field names here the same way registration does before
+    building the record. Returns True if an update was written.
+
+    Never changes the agent's wellKnownURI — discovery-URL changes only happen
+    via the admin PUT endpoint, which carries collision checks the worker lacks.
+    """
+    normalised = _normalise_fields(card_data)
+    candidate = agent_create_from_card(
+        normalised,
+        str(stored.wellKnownURI),
+        author_fallback=stored.author,
+    )
+    if not _metadata_differs(stored, candidate):
+        return False
+
+    await agent_repo.update(stored.id, candidate)
+    logger.info(
+        "agent_metadata_refreshed",
+        agent_id=stored.id,
+        name_change=(stored.name, candidate.name) if stored.name != candidate.name else None,
+        version_change=(stored.version, candidate.version) if stored.version != candidate.version else None,
+    )
+    return True
+
+
+async def refresh_recovery_notes(stored, category: str, agent_repo: AgentRepository) -> bool:
+    """Clear stale system-generated failure notes once an agent recovers.
+
+    When a probe flips to WORKING but the stored maintainer_notes is an old
+    system-authored failure note (e.g. a "404 Not Found" or "host down" message
+    from a previous probe), refresh it to the WORKING note so the displayed
+    state stops contradicting the live health/task status (#150, #153).
+
+    Human-authored notes are never touched. Returns True if notes were changed.
+    """
+    if category != "WORKING":
+        return False
+    current = (stored.maintainer_notes or "").strip()
+    # Only overwrite notes the registry itself wrote. Empty notes need no change;
+    # human notes must be preserved.
+    if not current or current not in _SYSTEM_AUTHORED_NOTES:
+        return False
+    working_note = CATEGORY_NOTES["WORKING"]
+    if current == working_note:
+        return False
+    await agent_repo.update_maintainer_notes(stored.id, working_note)
+    logger.info("recovery_notes_refreshed", agent_id=stored.id)
+    return True
+
+
 async def check_agent_health(
-    agent_id: UUID,
-    well_known_uri: str,
+    agent,
     session: aiohttp.ClientSession,
     health_repo: HealthCheckRepository,
     agent_repo: AgentRepository,
@@ -41,15 +115,17 @@ async def check_agent_health(
     Check health of a single agent by pinging its wellKnownURI.
 
     Args:
-        agent_id: UUID of the agent
-        well_known_uri: The agent's wellKnownURI endpoint
+        agent: The stored agent record (AgentPublic) to check and, if healthy,
+            refresh displayed metadata for.
         session: Aiohttp session for making requests
         health_repo: Repository for recording results
+        agent_repo: Repository for recording conformance/metadata updates
     """
+    agent_id = agent.id
+    well_known_uri = str(agent.wellKnownURI)
     bound_logger = logger.bind(agent_id=agent_id)
     start_time = time.time()
     status_code = None
-    success = False
     error_message = None
 
     try:
@@ -98,7 +174,6 @@ async def check_agent_health(
                 return
 
             # Valid JSON response — mark healthy
-            success = True
             await health_repo.create(
                 agent_id=agent_id,
                 status_code=status_code,
@@ -116,6 +191,15 @@ async def check_agent_health(
                 bound_logger.debug("conformance_updated", conformance=conformance, errors=errors[:3] if errors else [])
             except Exception as conf_err:
                 bound_logger.warning("conformance_check_failed", error=str(conf_err))
+
+            # Refresh the displayed card metadata (name/version/url/protocolVersion/
+            # description/skills/...) from the live card. Without this, an agent that
+            # renames or version-bumps shows frozen-at-registration metadata forever,
+            # even though we successfully fetch its current card every cycle (#153).
+            try:
+                await refresh_agent_metadata(agent, card_data, agent_repo)
+            except Exception as refresh_err:
+                bound_logger.warning("metadata_refresh_failed", error=str(refresh_err))
 
     except asyncio.TimeoutError:
         response_time_ms = int((time.time() - start_time) * 1000)
@@ -185,6 +269,12 @@ async def probe_one_task(agent, agent_repo: AgentRepository) -> str:
             user_agent=TASK_PROBE_USER_AGENT,
         )
         await agent_repo.update_task_conformance(agent.id, category, response_ms)
+        # If the agent recovered, drop any stale system-authored failure note so
+        # the displayed state stops contradicting the live result (#150, #153).
+        try:
+            await refresh_recovery_notes(agent, category, agent_repo)
+        except Exception as note_err:
+            bound_logger.warning("recovery_notes_refresh_failed", error=str(note_err))
         bound_logger.debug("task_probe_done", category=category, response_ms=response_ms)
         return category
     except Exception as exc:
@@ -258,8 +348,7 @@ async def health_check_cycle():
             batch = []
             for agent in check_agents:
                 task = check_agent_health(
-                    agent_id=agent.id,
-                    well_known_uri=str(agent.wellKnownURI),
+                    agent,
                     session=session,
                     health_repo=health_repo,
                     agent_repo=agent_repo,

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -4,10 +4,12 @@
 import asyncio
 import time
 from pathlib import Path
+from typing import Optional
 
 import aiohttp
+from pydantic import HttpUrl, TypeAdapter
 
-from app.agent_card import agent_create_from_card
+from app.agent_card import extract_agent_url, extract_protocol_version
 from app.config import settings
 from app.database import db
 from app.logging_config import configure_logging, get_logger
@@ -34,6 +36,10 @@ logger = get_logger(__name__)
 # these drifts from what we have stored, we re-fetch the full record. Excludes
 # wellKnownURI (the worker never changes an agent's discovery URL — only the PUT
 # endpoint does that, with collision checks).
+# Displayed card fields the worker keeps in sync with the live card, mapped to
+# how each is read out of a normalised card dict. Excludes wellKnownURI (only
+# the admin PUT changes discovery URLs) and everything the worker can't safely
+# re-derive from a card fetch (capabilities/skills/security/icon/auth flags).
 _REFRESHED_FIELDS = ("name", "version", "url", "protocolVersion", "description")
 
 # System-generated maintainer notes the worker is allowed to overwrite once an
@@ -41,43 +47,132 @@ _REFRESHED_FIELDS = ("name", "version", "url", "protocolVersion", "description")
 # registry itself (i.e. a human-written note) is left untouched.
 _SYSTEM_AUTHORED_NOTES = frozenset(CATEGORY_NOTES.values())
 
+# Coerce candidate URLs the same way the stored record does on read (the `url`
+# column round-trips through AgentBase.url: HttpUrl). Without this, a card URL
+# of "https://x.com" diffs forever against the stored "https://x.com/" that
+# HttpUrl produces, causing a rewrite every cycle.
+_HTTP_URL_ADAPTER = TypeAdapter(HttpUrl)
 
-def _metadata_differs(stored, candidate) -> bool:
-    """True if any displayed field on the live card differs from what we store."""
-    for field in _REFRESHED_FIELDS:
-        if str(getattr(stored, field, None)) != str(getattr(candidate, field, None)):
+
+def _canonical_url(value: str) -> str:
+    """Render a URL in the same canonical form HttpUrl uses, or return it
+    unchanged if it can't be parsed (the strict-validity gate already ran)."""
+    try:
+        return str(_HTTP_URL_ADAPTER.validate_python(value))
+    except Exception:
+        return value
+
+
+def _raw_has(raw_card: dict, *keys: str) -> bool:
+    """True if the RAW card carries a present, non-empty string under any of the
+    given key spellings.
+
+    Presence is judged against the raw (pre-normalisation) card on purpose:
+    _normalise_fields injects defaults (e.g. version='1.0.0' via setdefault),
+    so a normalised card always *looks* like it has a version even when the live
+    card omitted it. Reading presence from the raw card is what stops a default
+    from clobbering real stored data (PR #154 BLOCKING #1)."""
+    for key in keys:
+        value = raw_card.get(key)
+        if isinstance(value, str) and value.strip():
             return True
     return False
 
 
-async def refresh_agent_metadata(stored, card_data: dict, agent_repo: AgentRepository) -> bool:
-    """Re-sync displayed card metadata (name/version/url/protocolVersion/...) from
-    the live card when it has drifted from what we store.
+def _present_card_fields(raw_card: dict, normalised: dict) -> dict[str, str]:
+    """The displayed fields actually present (non-empty) in the live card.
 
-    The health worker fetches the raw card directly (not via fetch_agent_card),
-    so we normalise field names here the same way registration does before
-    building the record. Returns True if an update was written.
-
-    Never changes the agent's wellKnownURI — discovery-URL changes only happen
-    via the admin PUT endpoint, which carries collision checks the worker lacks.
+    Presence is decided from `raw_card` (so injected defaults never count);
+    values come from `normalised` (so snake_case spellings and v0.3/v1.0 shape
+    differences are already resolved). A field absent from the raw card is
+    omitted entirely — never written with a default.
     """
+    fields: dict[str, str] = {}
+
+    if _raw_has(raw_card, "name"):
+        fields["name"] = normalised["name"]
+    if _raw_has(raw_card, "version"):
+        fields["version"] = normalised["version"]
+    # description may legitimately be empty; only a present non-empty string is
+    # authoritative, so we never blank a real stored description.
+    if _raw_has(raw_card, "description"):
+        fields["description"] = normalised["description"]
+
+    # url present iff the card had a usable endpoint (top-level url or
+    # interfaces[].url). The extractor raises KeyError when neither exists.
+    if _raw_has(raw_card, "url", "interfaces", "supportedInterfaces"):
+        try:
+            url = extract_agent_url(normalised)
+            if isinstance(url, str) and url.strip():
+                # Canonicalise so it compares/writes stably against the stored
+                # HttpUrl form (avoids per-cycle rewrites on a trailing slash).
+                fields["url"] = _canonical_url(url)
+        except KeyError:
+            pass
+
+    # protocolVersion: present under either spelling, or nested in interfaces.
+    if _raw_has(raw_card, "protocolVersion", "protocol_version", "interfaces", "supportedInterfaces"):
+        protocol_version = extract_protocol_version(normalised)
+        # Sentinel 'unknown' means we couldn't actually read one — don't write it.
+        if isinstance(protocol_version, str) and protocol_version not in ("", "unknown"):
+            fields["protocolVersion"] = protocol_version
+
+    return fields
+
+
+async def refresh_agent_metadata(
+    stored,
+    card_data: dict,
+    agent_repo: AgentRepository,
+    *,
+    conformance_errors: Optional[list] = None,
+) -> bool:
+    """Re-sync displayed card metadata (name/version/url/protocolVersion/
+    description) from the live card when it has drifted.
+
+    Safety invariants (data-integrity, see PR #154 review):
+    - Only refreshes from a STRICT-valid card. If the live card has any
+      conformance errors, we skip — a degraded-but-parseable card must not
+      overwrite good stored data. Pass the strict-validation result in via
+      `conformance_errors`; when omitted we compute it here.
+    - Writes ONLY the five displayed fields via a column-scoped patch, never the
+      full record, so provider/capabilities/skills/icon/security/auth metadata
+      the worker can't re-derive are always preserved.
+    - Never writes a missing/empty card field over a stored value (see
+      _present_card_fields) and never changes wellKnownURI.
+
+    Returns True if an update was written.
+    """
+    # _normalise_fields returns a new dict (it does not mutate card_data), so
+    # card_data stays the RAW live card for presence detection.
     normalised = _normalise_fields(card_data)
-    candidate = agent_create_from_card(
-        normalised,
-        str(stored.wellKnownURI),
-        author_fallback=stored.author,
-    )
-    if not _metadata_differs(stored, candidate):
+
+    errors = conformance_errors
+    if errors is None:
+        errors = validate_agent_card(card_data, strict=True)
+    if errors:
+        # Degraded card — refresh nothing. Conformance is recorded separately.
         return False
 
-    await agent_repo.update(stored.id, candidate)
-    logger.info(
-        "agent_metadata_refreshed",
-        agent_id=stored.id,
-        name_change=(stored.name, candidate.name) if stored.name != candidate.name else None,
-        version_change=(stored.version, candidate.version) if stored.version != candidate.version else None,
-    )
-    return True
+    present = _present_card_fields(card_data, normalised)
+    changed = {
+        field: value
+        for field, value in present.items()
+        if str(getattr(stored, field, None)) != str(value)
+    }
+    if not changed:
+        return False
+
+    written = await agent_repo.update_card_metadata(stored.id, changed)
+    if written:
+        logger.info(
+            "agent_metadata_refreshed",
+            agent_id=stored.id,
+            fields=sorted(changed.keys()),
+            name_change=(stored.name, changed["name"]) if "name" in changed else None,
+            version_change=(stored.version, changed["version"]) if "version" in changed else None,
+        )
+    return written
 
 
 async def refresh_recovery_notes(stored, category: str, agent_repo: AgentRepository) -> bool:
@@ -184,20 +279,26 @@ async def check_agent_health(
             bound_logger.debug("health_check_ok", status_code=status_code, response_time_ms=response_time_ms)
 
             # Re-validate conformance from the live agent card
+            strict_errors: Optional[list] = None
             try:
-                errors = validate_agent_card(card_data, strict=True)
-                conformance = len(errors) == 0
-                await agent_repo.update_conformance(agent_id, conformance, errors=errors if errors else None)
-                bound_logger.debug("conformance_updated", conformance=conformance, errors=errors[:3] if errors else [])
+                strict_errors = validate_agent_card(card_data, strict=True)
+                conformance = len(strict_errors) == 0
+                await agent_repo.update_conformance(agent_id, conformance, errors=strict_errors if strict_errors else None)
+                bound_logger.debug("conformance_updated", conformance=conformance, errors=strict_errors[:3] if strict_errors else [])
             except Exception as conf_err:
                 bound_logger.warning("conformance_check_failed", error=str(conf_err))
 
             # Refresh the displayed card metadata (name/version/url/protocolVersion/
-            # description/skills/...) from the live card. Without this, an agent that
-            # renames or version-bumps shows frozen-at-registration metadata forever,
-            # even though we successfully fetch its current card every cycle (#153).
+            # description) from the live card. Only from a strict-valid card, and
+            # only the displayed columns — never the full record — so a degraded
+            # card can't overwrite good data with defaults or NULL out fields the
+            # worker can't re-derive (capabilities/skills/security/icon). See #153
+            # and the PR #154 review. If conformance validation above raised,
+            # strict_errors stays None and refresh_agent_metadata re-validates.
             try:
-                await refresh_agent_metadata(agent, card_data, agent_repo)
+                await refresh_agent_metadata(
+                    agent, card_data, agent_repo, conformance_errors=strict_errors,
+                )
             except Exception as refresh_err:
                 bound_logger.warning("metadata_refresh_failed", error=str(refresh_err))
 


### PR DESCRIPTION
## Problem

The health/conformance worker re-fetched each agent's live card every cycle and updated `conformance`/`task_conformance`, but **never re-synced the displayed metadata** (`name`/`version`/`url`/`protocolVersion`/`description`/`skills`). So any agent that renamed or version-bumped showed frozen-at-registration values forever. System-generated `maintainer_notes` (e.g. a "404" smoke-test note) were also never cleared once the agent recovered, leaving the displayed state contradicting the live health/task status.

This is the shared root cause behind two maintainer issues:

- **#153 (inferGONKA)** — registry shows "Gonka Cost Optimizer" v1.1.0 / protocolVersion `unknown`; live card is "inferGONKA" v1.3.0 / 0.3.0. Verified live via curl.
- **#150 (BidMachine)** — stale "host down" notes contradicted by the worker's own `is_healthy:true` / 100% uptime; task_conformance stuck at an old `passed:false`. (Already self-resolved on prod by the existing probes; this PR prevents recurrence.)

## Fix

- Extract the card→`AgentCreate` helpers out of `app/main.py` into a shared `app/agent_card.py` so the routes and the worker build the stored record identically. `main.py` keeps a thin wrapper that maps the transport-agnostic `ValueError` to `HTTPException(400)`, preserving the existing API contract.
- `worker.refresh_agent_metadata(agent, card_data, repo)` runs in the healthy path: normalises the raw fetched card (same as registration), diffs `_REFRESHED_FIELDS`, and only writes when something actually drifted (no `updated_at` churn). **Never** changes `wellKnownURI` — discovery-URL changes stay exclusive to the admin PUT endpoint, which carries the collision checks the worker lacks.
- `worker.refresh_recovery_notes(agent, category, repo)` runs in the task-probe path: when a probe flips to `WORKING`, it clears a stale **system-authored** failure note (matched against `CATEGORY_NOTES.values()`). Human-written notes are never touched.
- Removed two pieces of dead local state (`success`) in the function being edited.

Conformance already re-checks every cycle and task probes are 24h DB-backed, so the cadence was already sane — left unchanged.

## Tests

New `backend/tests/test_worker_refresh.py` (8 tests): name/version drift triggers a rewrite, no-op when the card matches, snake_case cards normalise, recovery clears system notes, human notes preserved, no-op when not WORKING / already WORKING / no notes.

`157 passed`. ruff clean on all changed files.

Closes #153