### PR TITLE
Read bounded Agent Card responses to EOF

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -40,6 +40,7 @@ _BLOCKED_SUFFIXES = (".internal", ".local", ".svc", ".cluster.local")
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 _MAX_AGENT_CARD_REDIRECTS = 3
 _MAX_AGENT_CARD_BYTES = 1_048_576
+_AGENT_CARD_CHUNK_BYTES = 65_536
 
 
 def _is_private_address(address: str) -> bool:
@@ -161,6 +162,16 @@ def _redirect_url(current_url: str, location: str | None) -> str:
     return next_url
 
 
+async def _read_bounded_body(content: Any, max_bytes: int) -> bytes | None:
+    """Read a streamed response to EOF without allowing it to exceed max_bytes."""
+    payload = bytearray()
+    async for chunk in content.iter_chunked(_AGENT_CARD_CHUNK_BYTES):
+        payload.extend(chunk)
+        if len(payload) > max_bytes:
+            return None
+    return bytes(payload)
+
+
 async def _get_guarded_json(url: str, *, user_agent: str) -> Tuple[Optional[dict[str, Any]], Optional[str]]:
     current_url = url
     for _redirect_count in range(_MAX_AGENT_CARD_REDIRECTS + 1):
@@ -188,8 +199,11 @@ async def _get_guarded_json(url: str, *, user_agent: str) -> Tuple[Optional[dict
                     return None, f"Agent card exceeds {_MAX_AGENT_CARD_BYTES} byte limit"
 
                 try:
-                    payload = await response.content.read(_MAX_AGENT_CARD_BYTES + 1)
-                    if len(payload) > _MAX_AGENT_CARD_BYTES:
+                    payload = await _read_bounded_body(
+                        response.content,
+                        _MAX_AGENT_CARD_BYTES,
+                    )
+                    if payload is None:
                         return None, f"Agent card exceeds {_MAX_AGENT_CARD_BYTES} byte limit"
                     return json.loads(payload), None
                 except Exception as e:

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -87,8 +87,8 @@ async def test_fetch_agent_card_follows_public_redirect_with_each_hop_guarded(mo
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def read(self, limit):
-            return json.dumps(self.payload).encode()[:limit]
+        async def iter_chunked(self, _chunk_size):
+            yield json.dumps(self.payload).encode()
 
     class FakeSession:
         def __init__(self, **_kwargs):
@@ -187,8 +187,8 @@ async def test_fetch_agent_card_accepts_public_non_redirect(monkeypatch):
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def read(self, limit):
-            return json.dumps(MOCK_AGENT_CARD).encode()[:limit]
+        async def iter_chunked(self, _chunk_size):
+            yield json.dumps(MOCK_AGENT_CARD).encode()
 
     class FakeSession:
         def __init__(self, **_kwargs):
@@ -246,3 +246,62 @@ async def test_fetch_agent_card_rejects_oversized_content_length(monkeypatch):
 
     assert card is None
     assert "byte limit" in error
+
+
+async def test_fetch_agent_card_reads_chunked_body_to_eof(monkeypatch):
+    """A stream read may produce partial chunks before the complete JSON body."""
+    payload = json.dumps(MOCK_AGENT_CARD).encode()
+    split_at = len(payload) // 2
+
+    async def fake_guarded_connector(_url):
+        return object()
+
+    class FakeResponse:
+        status = 200
+        content_length = len(payload)
+        content = None
+
+        def __init__(self):
+            self.content = self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def iter_chunked(self, _chunk_size):
+            yield payload[:split_at]
+            yield payload[split_at:]
+
+    class FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(utils, "_guarded_connector_for_url", fake_guarded_connector)
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", FakeSession)
+
+    card, error = await utils.fetch_agent_card(
+        "https://example.com/.well-known/agent.json"
+    )
+
+    assert error is None
+    assert card["name"] == MOCK_AGENT_CARD["name"]
+
+
+async def test_bounded_body_rejects_chunked_payload_over_limit():
+    class FakeContent:
+        async def iter_chunked(self, _chunk_size):
+            yield b"1234"
+            yield b"5678"
+
+    assert await utils._read_bounded_body(FakeContent(), 7) is None


### PR DESCRIPTION
## Summary

- stream Agent Card response bodies to EOF while retaining the 1 MiB cap
- avoid treating a legal partial `aiohttp.StreamReader.read(n)` result as the complete JSON document
- add split-stream and over-limit regression coverage

This surfaced while applying the approved canonical URL update in #156: the valid 53 KB card arrived in multiple network chunks and the registry attempted to parse only the first chunk.

## Verification

- `uv run --extra dev pytest tests/test_utils.py -v` (14 passed)
- `uv run --extra dev pytest` (184 passed)
- `uv run --extra dev ruff check app tests`
- `git diff --check`
