### PR TITLE
Update deployment actions to Node 24 releases

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -49,7 +49,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - uses: google-github-actions/auth@v3
         with:
@@ -59,7 +59,7 @@ jobs:
       - run: gcloud auth configure-docker gcr.io
 
       - name: Build and push backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: backend
           file: backend/Dockerfile
@@ -82,7 +82,7 @@ jobs:
           docker push gcr.io/${{ env.GCP_PROJECT_ID }}/a2a-registry-worker:latest
 
       - name: Build and push hello-world agent
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: hello-world-agent
           file: hello-world-agent/Dockerfile
@@ -97,7 +97,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: website
           file: website/Dockerfile
@@ -138,7 +138,7 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_REGION }}
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: '3.14.0'
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       - 'backend/**'
-      - '.github/workflows/administer-agent.yml'
-      - '.github/workflows/pr-ci.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- update `docker/setup-buildx-action` from v3 to v4
- update `docker/build-push-action` from v6 to v7
- update `azure/setup-helm` from v4 to v5

These are the current official major releases and remove the Node 20 forced-runtime warnings observed in the production rollout.

## Verification

- `git diff --check`
- `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color .github/workflows/*.yml`

Official release references:
- https://github.com/docker/setup-buildx-action/releases/tag/v4.2.0
- https://github.com/docker/build-push-action/releases/tag/v7.3.0
- https://github.com/Azure/setup-helm/releases/tag/v5.0.1
