### PR TITLE
Keep v1 Agent Cards current and render metadata accurately

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+      - 'website/**'
       - '.github/workflows/**'
 
 permissions:
@@ -36,3 +37,21 @@ jobs:
 
       - name: Run ruff
         run: uv run --extra dev ruff check app tests
+
+  website:
+    name: Website build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - run: npm ci
+      - run: npm run build

--- a/backend/app/agent_card.py
+++ b/backend/app/agent_card.py
@@ -75,8 +75,11 @@ def agent_create_from_card(
             provider=agent_card.get("provider"),
             documentationUrl=agent_card.get("documentationUrl"),
             iconUrl=agent_card.get("iconUrl"),
-            supportsAuthenticatedExtendedCard=agent_card.get("supportsAuthenticatedExtendedCard"),
-            security=agent_card.get("security"),
+            supportsAuthenticatedExtendedCard=agent_card.get(
+                "supportsAuthenticatedExtendedCard",
+                capabilities.get("extendedAgentCard"),
+            ),
+            security=agent_card.get("security", agent_card.get("securityRequirements")),
             securitySchemes=agent_card.get("securitySchemes"),
             capabilities=capabilities,
             defaultInputModes=agent_card.get("defaultInputModes", ["text/plain"]),

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -344,9 +344,24 @@ class AgentRepository:
         "provider": "provider",
         "security": "security_requirements",
         "securitySchemes": "security_schemes",
+        "documentationUrl": "documentation_url",
+        "iconUrl": "icon_url",
+        "supportsAuthenticatedExtendedCard": "supports_authenticated_extended_card",
+        "capabilities": "capabilities",
+        "defaultInputModes": "default_input_modes",
+        "defaultOutputModes": "default_output_modes",
+        "skills": "skills",
     }
 
-    _WORKER_JSON_FIELDS = {"provider", "security", "securitySchemes"}
+    _WORKER_JSON_FIELDS = {
+        "provider",
+        "security",
+        "securitySchemes",
+        "capabilities",
+        "defaultInputModes",
+        "defaultOutputModes",
+        "skills",
+    }
 
     async def update_card_metadata(self, agent_id: UUID, fields: dict) -> bool:
         """Patch only the supplied displayed-metadata columns, preserving all others.

--- a/backend/app/smoke_test.py
+++ b/backend/app/smoke_test.py
@@ -41,7 +41,7 @@ CATEGORY_NOTES = {
     "BAD_RESPONSE": "Agent responds but the response shape is missing required A2A fields. Standard A2A SDK clients cannot parse the response. Update your response format to match the A2A spec.",
     "BAD_JSON": "Agent endpoint does not return valid JSON for `message/send` requests. Ensure the endpoint returns a proper JSON-RPC response.",
     "METHOD": "Agent does not implement the `message/send` JSON-RPC method. Add support for this method per the A2A spec.",
-    "PARSE": "Agent's gRPC/protobuf response includes a field not defined in the A2A schema. Align response with the latest A2A spec.",
+    "PARSE": "The official A2A SDK could not parse the `message/send` response because its result does not match the declared protocol schema. For A2A v1.0, return a `SendMessageResponse` containing `task` or `message`, rather than an unwrapped Task object.",
     "AUTH_BACKEND": "Agent endpoint reachable but returns an internal authentication error from a downstream LLM provider (invalid API key on the agent's side). The agent operator needs to fix their backend credentials.",
     "INTERNAL": "Agent endpoint reachable but returns an A2A `InternalError` when handling `message/send`. Check server-side error logs.",
     "TIMEOUT": "Agent endpoint did not respond within the smoke-test timeout. Could be transient; will be re-checked by the health worker.",

--- a/backend/app/validators.py
+++ b/backend/app/validators.py
@@ -87,6 +87,19 @@ def _normalise_fields(card: dict[str, Any]) -> dict[str, Any]:
         if snake in result and camel not in result:
             result[camel] = result.pop(snake)
 
+    # v1.0 renamed the top-level security requirements collection.
+    if "securityRequirements" in result and "security" not in result:
+        result["security"] = result["securityRequirements"]
+
+    # v1.0 moved this declaration under capabilities.extendedAgentCard.
+    capabilities = result.get("capabilities")
+    if (
+        "supportsAuthenticatedExtendedCard" not in result
+        and isinstance(capabilities, dict)
+        and isinstance(capabilities.get("extendedAgentCard"), bool)
+    ):
+        result["supportsAuthenticatedExtendedCard"] = capabilities["extendedAgentCard"]
+
     # v1.0 compat: extract url and protocolVersion from interfaces[]
     if "url" not in result:
         for key in ("interfaces", "supportedInterfaces"):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     "aiohttp>=3.9.0",
     "structlog>=24.0.0",
-    "a2a-sdk==1.0.0a3",
+    "a2a-sdk==1.1.2",
     "posthog>=3.1.0",
     "python-multipart>=0.0.6",
     "alembic>=1.13.0",

--- a/backend/tests/test_smoke_test.py
+++ b/backend/tests/test_smoke_test.py
@@ -113,6 +113,12 @@ def test_every_category_has_a_note():
         assert CATEGORY_NOTES[cat]
 
 
+def test_parse_note_explains_v1_response_envelope():
+    assert "SendMessageResponse" in CATEGORY_NOTES["PARSE"]
+    assert "task" in CATEGORY_NOTES["PARSE"]
+    assert "message" in CATEGORY_NOTES["PARSE"]
+
+
 # --- smoke_test() timing regression ----------------------------------------
 #
 # smoke_test() once started its timer with time.monotonic() but measured the

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -362,3 +362,17 @@ def test_normalise_v1_defaults_description_and_version():
     result = _normalise_fields(card)
     assert result["description"] == ""
     assert result["version"] == "1.0.0"
+
+
+def test_normalise_v1_security_and_extended_card_fields():
+    card = {
+        "name": "V1 Agent",
+        "url": "https://example.com/a2a",
+        "securityRequirements": [{"apiKey": []}],
+        "capabilities": {"streaming": False, "extendedAgentCard": True},
+    }
+
+    result = _normalise_fields(card)
+
+    assert result["security"] == [{"apiKey": []}]
+    assert result["supportsAuthenticatedExtendedCard"] is True

--- a/backend/tests/test_worker_refresh.py
+++ b/backend/tests/test_worker_refresh.py
@@ -14,6 +14,7 @@ import pytest
 
 import worker
 from app.agent_card import agent_create_from_card
+from app.models import Skill
 from app.repositories import AgentRepository
 from app.smoke_test import CATEGORY_NOTES
 
@@ -36,6 +37,17 @@ def _stored_agent(**overrides):
         provider=None,
         security=[],
         securitySchemes={},
+        documentationUrl=None,
+        iconUrl=None,
+        supportsAuthenticatedExtendedCard=None,
+        capabilities={
+            "streaming": False,
+            "pushNotifications": False,
+            "stateTransitionHistory": False,
+        },
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["text/plain"],
+        skills=[],
     )
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -87,6 +99,21 @@ def test_registration_model_preserves_auth_declarations():
 
     assert agent.security == [{"apiKey": []}]
     assert agent.securitySchemes["apiKey"]["name"] == "x-api-key"
+
+
+def test_registration_model_normalises_v1_security_and_extended_card():
+    card = _live_card_v1(
+        securityRequirements=[{"apiKey": []}],
+        securitySchemes={"apiKey": {"type": "apiKey", "in": "header"}},
+        capabilities={"streaming": False, "extendedAgentCard": True},
+    )
+
+    agent = agent_create_from_card(
+        card, "https://example.com/.well-known/agent-card.json"
+    )
+
+    assert agent.security == [{"apiKey": []}]
+    assert agent.supportsAuthenticatedExtendedCard is True
 
 
 # ── refresh_agent_metadata ──────────────────────────────────────────────────
@@ -159,6 +186,18 @@ async def test_refresh_noop_when_card_matches_stored():
     repo.update_card_metadata.assert_not_awaited()
 
 
+def test_comparable_handles_model_objects_nested_in_lists():
+    skill_model = Skill(
+        id="onboarding",
+        name="Get started",
+        description="Register an account.",
+        tags=["onboarding"],
+    )
+    skill_dict = skill_model.model_dump(mode="json", exclude_none=True)
+
+    assert worker._comparable([skill_model]) == worker._comparable([skill_dict])
+
+
 async def test_refresh_normalises_snake_case_card():
     """Cards using snake_case field names (SDK style) still refresh correctly."""
     stored = _stored_agent()
@@ -229,18 +268,59 @@ async def test_refresh_present_field_extraction_never_synthesises_version():
     assert fields["name"] == "inferGONKA"
 
 
-async def test_refresh_preserves_unrelated_fields_via_scoped_patch():
-    """A metadata drift must not touch fields outside the refresh whitelist."""
-    stored = _stored_agent()
+async def test_refresh_updates_explicit_card_fields_via_scoped_patch():
+    """Strict-valid, explicitly present Agent Card fields stay current."""
+    stored = _stored_agent(
+        documentationUrl="https://old.example/docs",
+        iconUrl="https://old.example/icon.png",
+        skills=[{"id": "old"}],
+    )
+    repo = _metadata_repo()
+    card = _live_card(
+        documentationUrl="https://new.example/docs",
+        iconUrl="https://new.example/icon.png",
+        capabilities={"streaming": True, "extendedAgentCard": True},
+        defaultInputModes=["application/json"],
+        defaultOutputModes=["application/json"],
+        skills=[
+            {
+                "id": "onboarding",
+                "name": "Get started",
+                "description": "Register an account.",
+                "tags": ["onboarding"],
+            }
+        ],
+    )
+
+    await worker.refresh_agent_metadata(stored, card, repo)
+
+    _, fields = repo.update_card_metadata.await_args.args
+    assert fields["documentationUrl"] == "https://new.example/docs"
+    assert fields["iconUrl"] == "https://new.example/icon.png"
+    assert fields["supportsAuthenticatedExtendedCard"] is True
+    assert fields["capabilities"]["streaming"] is True
+    assert "extendedAgentCard" not in fields["capabilities"]
+    assert fields["defaultInputModes"] == ["application/json"]
+    assert fields["defaultOutputModes"] == ["application/json"]
+    assert fields["skills"][0]["id"] == "onboarding"
+
+
+async def test_refresh_absent_optional_card_fields_preserve_stored_values():
+    stored = _stored_agent(
+        documentationUrl="https://existing.example/docs",
+        iconUrl="https://existing.example/icon.png",
+        supportsAuthenticatedExtendedCard=True,
+    )
     repo = _metadata_repo()
 
     await worker.refresh_agent_metadata(stored, _live_card(), repo)
 
     _, fields = repo.update_card_metadata.await_args.args
-    for protected in ("iconUrl", "supportsAuthenticatedExtendedCard", "capabilities", "skills"):
-        assert protected not in fields
-    # And the repo whitelist itself rejects non-re-derived fields.
-    assert "icon_url" not in AgentRepository._WORKER_REFRESHABLE_COLUMNS.values()
+    assert not {
+        "documentationUrl",
+        "iconUrl",
+        "supportsAuthenticatedExtendedCard",
+    } & fields.keys()
 
 
 async def test_refresh_updates_provider_and_security_when_declared():
@@ -426,6 +506,22 @@ async def test_system_note_tracks_transition_between_failure_categories():
     repo.update_maintainer_notes.assert_awaited_once_with(stored.id, CATEGORY_NOTES["401"])
 
 
+async def test_legacy_system_note_updates_to_current_category_wording():
+    legacy_note = (
+        "Agent's gRPC/protobuf response includes a field not defined in the A2A "
+        "schema. Align response with the latest A2A spec."
+    )
+    stored = _stored_agent(maintainer_notes=legacy_note)
+    repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
+
+    changed = await worker.refresh_recovery_notes(stored, "PARSE", repo)
+
+    assert changed is True
+    repo.update_maintainer_notes.assert_awaited_once_with(
+        stored.id, CATEGORY_NOTES["PARSE"]
+    )
+
+
 async def test_system_note_noop_when_failure_category_matches():
     stored = _stored_agent(maintainer_notes=CATEGORY_NOTES["404"])
     repo = SimpleNamespace(update_maintainer_notes=AsyncMock())
@@ -475,9 +571,8 @@ async def test_update_card_metadata_writes_only_whitelisted_columns():
     sql = db.execute.await_args.args[0]
     assert "name = $1" in sql and "version = $2" in sql and "protocol_version = $3" in sql
     assert "updated_at = NOW()" in sql
-    # Columns the worker must never write must be absent from the statement.
-    for forbidden in ("capabilities", "skills", "icon_url",
-                      "supports_authenticated_extended_card", "well_known_uri"):
+    # Registry-owned columns remain outside the worker patch surface.
+    for forbidden in ("well_known_uri", "author", "license", "pricing", "contact"):
         assert forbidden not in sql
     # Values are bound positionally; the id is the last parameter.
     assert db.execute.await_args.args[-1] == "abc"
@@ -489,7 +584,7 @@ async def test_update_card_metadata_rejects_unknown_field():
     repo = AgentRepository(db)
 
     with pytest.raises(ValueError, match="not worker-refreshable"):
-        await repo.update_card_metadata("abc", {"capabilities": {"evil": 1}})
+        await repo.update_card_metadata("abc", {"license": "MIT"})
 
     db.execute.assert_not_awaited()
 
@@ -515,6 +610,35 @@ async def test_update_card_metadata_serialises_auth_json_fields():
     assert json.loads(provider) == {"organization": "Cog Depot"}
     assert json.loads(security) == [{"apiKey": []}]
     assert json.loads(schemes) == {"apiKey": {"type": "apiKey"}}
+    assert agent_id == "abc"
+
+
+async def test_update_card_metadata_serialises_display_card_fields():
+    db = SimpleNamespace(execute=AsyncMock(return_value="UPDATE 1"))
+    repo = AgentRepository(db)
+
+    written = await repo.update_card_metadata(
+        "abc",
+        {
+            "documentationUrl": "https://example.com/docs",
+            "capabilities": {"streaming": True},
+            "defaultInputModes": ["application/json"],
+            "skills": [{"id": "onboarding"}],
+        },
+    )
+
+    assert written is True
+    sql, documentation_url, capabilities, input_modes, skills, agent_id = (
+        db.execute.await_args.args
+    )
+    assert "documentation_url = $1" in sql
+    assert "capabilities = $2" in sql
+    assert "default_input_modes = $3" in sql
+    assert "skills = $4" in sql
+    assert documentation_url == "https://example.com/docs"
+    assert json.loads(capabilities) == {"streaming": True}
+    assert json.loads(input_modes) == ["application/json"]
+    assert json.loads(skills) == [{"id": "onboarding"}]
     assert agent_id == "abc"
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,7 +39,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = "==1.0.0a3" },
+    { name = "a2a-sdk", specifier = "==1.1.2" },
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "apscheduler", specifier = ">=3.10.0" },
@@ -64,22 +64,21 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.0a3"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "culsans", marker = "python_full_version < '3.13'" },
     { name = "google-api-core" },
     { name = "googleapis-common-protos" },
     { name = "httpx" },
-    { name = "httpx-sse" },
     { name = "json-rpc" },
     { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/41/a742f2e3c94ac7388bd43230e50079d7b9158331312bcccc5d149177a2c7/a2a_sdk-1.0.0a3.tar.gz", hash = "sha256:65483a01150718ab59d0a1216bf27fcd7d9547fa339e50447594afe791c29cea", size = 379213, upload-time = "2026-04-17T15:48:21.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/cc/59b35c518d8289bd59d20d9d216ca29ccb41c4697eb85971efe41d1adaf3/a2a_sdk-1.1.2.tar.gz", hash = "sha256:f928d8bf9a0dc0a473ee8258bd5226c1b8520a85c70e7f233c3b9b0e30a1bd10", size = 379627, upload-time = "2026-07-22T13:40:51.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/29/215b8b9c7b9a99f6fbcabfb29ff009eeaadde69136454f8a8f3775b47d47/a2a_sdk-1.0.0a3-py3-none-any.whl", hash = "sha256:b915430ed5fe7ca7906da3e69f8cb1bef0f9ad9d7dfc4eb3a292384e4e02850b", size = 237008, upload-time = "2026-04-17T15:48:19.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/33/d414a03d5ef5a7d6d09a20dc9f8094e7fb9edb488662ff99c535a2a62cf1/a2a_sdk-1.1.2-py3-none-any.whl", hash = "sha256:eb9a698f526dc45a9ea967d7804e7aa363ff273d2c44fbed699bc68c9399f9c9", size = 245981, upload-time = "2026-07-22T13:40:49.484Z" },
 ]
 
 [[package]]

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import aiohttp
 from pydantic import HttpUrl, TypeAdapter
@@ -14,6 +14,7 @@ from app.agent_card import extract_agent_url, extract_protocol_version
 from app.config import settings
 from app.database import db
 from app.logging_config import configure_logging, get_logger
+from app.models import Capabilities
 from app.repositories import AgentRepository, HealthCheckRepository
 from app.smoke_test import CATEGORY_NOTES, TASK_PROBE_USER_AGENT, smoke_test
 from app.validators import _normalise_fields, validate_agent_card
@@ -33,10 +34,9 @@ configure_logging(json_logs=True)
 logger = get_logger(__name__)
 
 
-# Displayed card fields the worker keeps in sync with the live card, mapped to
-# how each is read out of a normalised card dict. Excludes wellKnownURI (only
-# the admin PUT changes discovery URLs). Provider and authentication declarations
-# are safe to refresh because they come directly from the same strict-valid card.
+# Agent Card fields the worker keeps in sync with the live card. Excludes
+# wellKnownURI (only the admin PUT changes discovery URLs) and registry-owned
+# extensions such as author/contact/license/pricing.
 _REFRESHED_FIELDS = (
     "name",
     "version",
@@ -46,12 +46,26 @@ _REFRESHED_FIELDS = (
     "provider",
     "security",
     "securitySchemes",
+    "documentationUrl",
+    "iconUrl",
+    "supportsAuthenticatedExtendedCard",
+    "capabilities",
+    "defaultInputModes",
+    "defaultOutputModes",
+    "skills",
 )
+
+# Superseded registry-authored wording remains recognizable so a copy update
+# cannot turn yesterday's system note into a permanently protected "human" note.
+_LEGACY_SYSTEM_AUTHORED_NOTES = frozenset({
+    "Agent's gRPC/protobuf response includes a field not defined in the A2A schema. "
+    "Align response with the latest A2A spec.",
+})
 
 # System-generated maintainer notes the worker is allowed to keep aligned with
 # task-probe categories. Anything not authored by the registry itself (i.e. a
 # human-written note) is left untouched.
-_SYSTEM_AUTHORED_NOTES = frozenset(CATEGORY_NOTES.values())
+_SYSTEM_AUTHORED_NOTES = frozenset(CATEGORY_NOTES.values()) | _LEGACY_SYSTEM_AUTHORED_NOTES
 
 # Coerce candidate URLs the same way the stored record does on read (the `url`
 # column round-trips through AgentBase.url: HttpUrl). Without this, a card URL
@@ -129,7 +143,7 @@ def _present_card_fields(raw_card: dict, normalised: dict) -> dict:
     interfaces[0].url/protocolVersion to top level). A field absent from the raw
     card is omitted entirely — never written with a default.
     """
-    fields: dict[str, str] = {}
+    fields: dict[str, Any] = {}
 
     if _raw_has(raw_card, "name"):
         fields["name"] = normalised["name"]
@@ -168,13 +182,57 @@ def _present_card_fields(raw_card: dict, normalised: dict) -> dict:
     if isinstance(normalised.get("securitySchemes"), dict):
         fields["securitySchemes"] = normalised["securitySchemes"]
 
+    for raw_keys, field in (
+        (("documentationUrl", "documentation_url"), "documentationUrl"),
+        (("iconUrl", "icon_url"), "iconUrl"),
+    ):
+        if _raw_has(raw_card, *raw_keys) and _raw_str(normalised.get(field)):
+            fields[field] = _canonical_url(normalised[field])
+
+    capabilities = raw_card.get("capabilities")
+    if isinstance(capabilities, dict):
+        fields["capabilities"] = Capabilities.model_validate(
+            normalised["capabilities"]
+        ).model_dump(mode="json", exclude_none=True)
+    if isinstance(normalised.get("supportsAuthenticatedExtendedCard"), bool) and (
+        "supportsAuthenticatedExtendedCard" in raw_card
+        or "supports_authenticated_extended_card" in raw_card
+        or (
+            isinstance(capabilities, dict)
+            and isinstance(capabilities.get("extendedAgentCard"), bool)
+        )
+    ):
+        fields["supportsAuthenticatedExtendedCard"] = normalised[
+            "supportsAuthenticatedExtendedCard"
+        ]
+
+    for raw_keys, field in (
+        (("defaultInputModes", "default_input_modes"), "defaultInputModes"),
+        (("defaultOutputModes", "default_output_modes"), "defaultOutputModes"),
+        (("skills",), "skills"),
+    ):
+        if any(key in raw_card for key in raw_keys) and isinstance(
+            normalised.get(field), list
+        ):
+            fields[field] = normalised[field]
+
     return fields
+
+
+def _jsonable(value):
+    """Recursively convert model-backed JSON values to plain Python values."""
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    return value
 
 
 def _comparable(value):
     """Return a stable representation for comparing model-backed JSON fields."""
-    if hasattr(value, "model_dump"):
-        value = value.model_dump(mode="json", exclude_none=True)
+    value = _jsonable(value)
     if isinstance(value, (dict, list)):
         return json.dumps(value, sort_keys=True, separators=(",", ":"))
     return str(value)
@@ -188,17 +246,16 @@ async def refresh_agent_metadata(
     conformance_errors: Optional[list] = None,
 ) -> bool:
     """Re-sync displayed card metadata (name/version/url/protocolVersion/
-    description/provider/security declarations) from the live card when it has
-    drifted.
+    description and other explicit Agent Card declarations) from the live card
+    when they have drifted.
 
     Safety invariants (data-integrity, see PR #154 review):
     - Only refreshes from a STRICT-valid card. If the live card has any
       conformance errors, we skip — a degraded-but-parseable card must not
       overwrite good stored data. Pass the strict-validation result in via
       `conformance_errors`; when omitted we compute it here.
-    - Writes only the explicit refresh whitelist via a column-scoped patch,
-      never the full record. Capabilities/skills/icon and other fields remain
-      untouched.
+    - Writes only the explicit Agent Card whitelist via a column-scoped patch,
+      never registry-owned fields or the full record.
     - Never writes a missing/empty card field over a stored value (see
       _present_card_fields) and never changes wellKnownURI.
 
@@ -348,19 +405,32 @@ async def check_agent_health(
             except Exception as conf_err:
                 bound_logger.warning("conformance_check_failed", error=str(conf_err))
 
-            # Refresh the displayed card metadata (name/version/url/protocolVersion/
-            # description) from the live card. Only from a strict-valid card, and
-            # only the displayed columns — never the full record — so a degraded
-            # card can't overwrite good data with defaults or NULL out fields the
-            # worker can't re-derive (capabilities/skills/security/icon). See #153
-            # and the PR #154 review. If conformance validation above raised,
-            # strict_errors stays None and refresh_agent_metadata re-validates.
+            # Refresh explicit Agent Card metadata from the live card. Only from
+            # a strict-valid card, and only the whitelisted card columns — never
+            # the full record — so degraded/partial cards cannot overwrite good
+            # stored data or registry-owned fields. See #153/#158/#166 and the
+            # PR #154 review. If validation above raised, strict_errors stays None
+            # and refresh_agent_metadata re-validates.
             try:
                 await refresh_agent_metadata(
                     agent, card_data, agent_repo, conformance_errors=strict_errors,
                 )
             except Exception as refresh_err:
                 bound_logger.warning("metadata_refresh_failed", error=str(refresh_err))
+
+            # Reconcile system-note wording every health cycle as well as after
+            # task probes. This updates renamed category guidance promptly while
+            # preserving the last measured category and all human-authored notes.
+            task_conformance = getattr(agent, "task_conformance", None)
+            if task_conformance:
+                try:
+                    await refresh_recovery_notes(
+                        agent,
+                        task_conformance.category,
+                        agent_repo,
+                    )
+                except Exception as note_err:
+                    bound_logger.warning("system_notes_refresh_failed", error=str(note_err))
 
     except asyncio.TimeoutError:
         response_time_ms = int((time.time() - start_time) * 1000)

--- a/website/src/components/AgentCard.jsx
+++ b/website/src/components/AgentCard.jsx
@@ -3,9 +3,11 @@ import { ArrowUpRight, ShieldCheck, ShieldAlert, Radio, CheckCircle2, AlertTrian
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import HealthBadge from './HealthBadge';
+import { agentProvider, formatVersion } from '@/lib/utils';
 
 const AgentCard = ({ agent, isSelected, onClick }) => {
-    const provider = agent.author || agent.provider?.organization || 'Unknown';
+    const provider = agentProvider(agent);
+    const version = formatVersion(agent.version);
     const topTags = agent.skills.flatMap((skill) => skill.tags || []).slice(0, 3);
     const notes = agent.maintainer_notes || '';
     // Prefer the structured task_conformance signal — it's kept current by the
@@ -77,7 +79,7 @@ const AgentCard = ({ agent, isSelected, onClick }) => {
                         {agent.name}
                     </h3>
                     <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
-                        <span>v{agent.version}</span>
+                        {version && <span>{version}</span>}
                         <span className="text-zinc-700">•</span>
                         <span className="truncate">{provider}</span>
                     </div>

--- a/website/src/components/InspectionDeck.jsx
+++ b/website/src/components/InspectionDeck.jsx
@@ -4,7 +4,7 @@ import { X, Globe, FileText, Zap, Flag, Copy, Check, ArrowUpRight, ChevronLeft, 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { safeExternalUrl } from '@/lib/utils';
+import { agentProvider, formatVersion, safeExternalUrl } from '@/lib/utils';
 import Terminal from './Terminal';
 import HealthBadge from './HealthBadge';
 import { api } from '@/lib/api';
@@ -135,9 +135,9 @@ const AgentHero = ({ agent, mobile }) => (
             {agent.name}
         </h2>
         <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
-            <span>v{agent.version}</span>
+            {formatVersion(agent.version) && <span>{formatVersion(agent.version)}</span>}
             <span className="text-zinc-700">•</span>
-            <span>{agent.author || agent.provider?.organization || 'Unknown'}</span>
+            <span>{agentProvider(agent)}</span>
             {agent.protocolVersion && (
                 <>
                     <span className="text-zinc-700">•</span>
@@ -214,11 +214,11 @@ const AgentSections = ({ agent, mobile, onOpenReport }) => {
                     <dl className="mt-4 grid grid-cols-2 gap-4 text-sm">
                         <div>
                             <dt className="text-[10px] uppercase tracking-[0.18em] text-zinc-600">Provider</dt>
-                            <dd className="mt-1 text-zinc-200">{agent.author || agent.provider?.organization || 'Unknown'}</dd>
+                            <dd className="mt-1 text-zinc-200">{agentProvider(agent)}</dd>
                         </div>
                         <div>
                             <dt className="text-[10px] uppercase tracking-[0.18em] text-zinc-600">License</dt>
-                            <dd className="mt-1 text-zinc-200">{agent.license || 'MIT'}</dd>
+                            <dd className="mt-1 text-zinc-200">{agent.license || 'Not declared'}</dd>
                         </div>
                     </dl>
                     {agent.wellKnownURI && (

--- a/website/src/lib/utils.js
+++ b/website/src/lib/utils.js
@@ -19,3 +19,19 @@ export function safeExternalUrl(value) {
 
   return null
 }
+
+export function agentProvider(agent) {
+  const provider = agent?.provider?.organization?.trim()
+  if (provider) return provider
+
+  const author = agent?.author?.trim()
+  if (author && author.toLowerCase() !== "unknown") return author
+
+  return "Unknown"
+}
+
+export function formatVersion(value) {
+  const version = String(value ?? "").trim()
+  if (!version) return null
+  return /^v/i.test(version) ? version : `v${version}`
+}

--- a/website/src/pages/agents/[slug].astro
+++ b/website/src/pages/agents/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import AgentPageClient from '@/components/AgentPageClient.jsx';
-import { safeExternalUrl } from '@/lib/utils';
+import { agentProvider, formatVersion, safeExternalUrl } from '@/lib/utils';
 
 export const prerender = true;
 
@@ -58,7 +58,8 @@ export async function getStaticPaths() {
 
 const { agent } = Astro.props;
 
-const provider = agent.author || agent.provider?.organization || 'Unknown';
+const provider = agentProvider(agent);
+const displayVersion = formatVersion(agent.version);
 const title = `${agent.name} - A2A Protocol Agent | ${provider}`;
 
 // Strip common inline Markdown so agents with **bold** / [link](url) /
@@ -178,7 +179,7 @@ const jsonLd = [
 
         <h2 class="mt-4 font-mono text-2xl font-semibold text-zinc-100">{agent.name}</h2>
         <p class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
-          {agent.version && <><span>v{agent.version}</span><span class="text-zinc-700">•</span></>}
+          {displayVersion && <><span>{displayVersion}</span><span class="text-zinc-700">•</span></>}
           <span>{provider}</span>
           {agent.license && <><span class="text-zinc-700">•</span><span>{agent.license}</span></>}
         </p>


### PR DESCRIPTION
## Summary

- refresh all explicitly present, strict-valid Agent Card display fields while preserving registry-owned metadata and partial-card safety
- normalize A2A v1 `securityRequirements` and `capabilities.extendedAgentCard`
- update the official A2A Python SDK from pre-release `1.0.0a3` to stable `1.1.2`
- make PARSE guidance accurately describe the v1 `SendMessageResponse` envelope
- recognize legacy system-note wording and reconcile it on regular health cycles
- prefer declared provider metadata, stop assuming an undeclared MIT license, and avoid duplicated `v` prefixes
- add website builds to PR CI

## #166 disposition

A direct probe with the latest official SDK confirms CogDepot returns an unwrapped Task object under JSON-RPC `result`. A2A v1.0 expects a `SendMessageResponse` containing `task` or `message`, so TASK_VERIFIED should remain false until the endpoint wraps that result. The registry now explains this precisely.

The production record itself has already been refreshed through the audited operator workflow and now contains the current documentation URL, onboarding skill, provider, v1 endpoint, and version.

## Verification

- `uv run --extra dev pytest -q` — 191 passed
- `uv run --extra dev ruff check app tests worker.py`
- live CogDepot probe with `a2a-sdk 1.1.2` — deterministic PARSE on unwrapped `result.id`
- live strict-card extraction — no errors; all expected v1 fields selected
- frontend metadata helper assertions
- `npm ci` / `npm run build` — 103 pages
- `npm audit` — 0 vulnerabilities
- backend Docker image build
- actionlint across all workflows
- `git diff --check`

Closes #166
